### PR TITLE
Use FQCN for cert_info module

### DIFF
--- a/molecule/plugins/converge.yml
+++ b/molecule/plugins/converge.yml
@@ -8,7 +8,7 @@
     # Test modules
     #
     - name: Test
-      cert_info:
+      oddly.elasticstack.cert_info:
         path: files/es-ca/elastic-stack-ca.p12
         passphrase: PleaseChangeMe
       register: test
@@ -16,11 +16,11 @@
       ansible.builtin.debug:
         msg: "{{ test }}"
     - name: Test required parameters (missing path)
-      cert_info:
+      oddly.elasticstack.cert_info:
         passphrase: PleaseChangeMe
       failed_when: false
     - name: Test wrong path
-      cert_info:
+      oddly.elasticstack.cert_info:
         path: es-ca-wrong
         passphrase: PleaseChangeMe
       failed_when: false
@@ -29,14 +29,14 @@
         msg: >-
           "{{ ((test.not_valid_after | regex_replace('[+-]\d{2}:\d{2}$', '') | to_datetime('%Y-%m-%d %H:%M:%S')) - (ansible_date_time.date | to_datetime('%Y-%m-%d'))).days }}"
     - name: Test wrong passphrase
-      cert_info:
+      oddly.elasticstack.cert_info:
         path: files/es-ca/elastic-stack-ca.p12
         passphrase: PleaseChangeMe-wrong
       failed_when: false
     - name: Test no passphrase
-      cert_info:
+      oddly.elasticstack.cert_info:
         path: files/es-ca/elastic-stack-ca.p12
       failed_when: false
     - name: Test no parameters
-      cert_info:
+      oddly.elasticstack.cert_info:
       failed_when: false

--- a/roles/elasticstack/tasks/certs/cert_check_expiry.yml
+++ b/roles/elasticstack/tasks/certs/cert_check_expiry.yml
@@ -24,7 +24,7 @@
   when: elasticstack_cert_stat.stat.exists
   block:
     - name: Get certificate info
-      cert_info:
+      oddly.elasticstack.cert_info:
         path: "{{ _cert_path }}"
         passphrase: "{{ _cert_pass | default(omit, true) }}"
         format: "{{ _cert_format | default('p12') }}"


### PR DESCRIPTION
## Summary
- Replace bare `cert_info` module references with `oddly.elasticstack.cert_info` (FQCN)
- Fixes module resolution when the role is used via `ANSIBLE_ROLES_PATH` instead of as a collection

Closes #22

## Changed files
- `roles/elasticstack/tasks/certs/cert_check_expiry.yml`
- `molecule/plugins/converge.yml`

## Test plan
- [ ] Run playbook with role via `ANSIBLE_ROLES_PATH` — `cert_info` should resolve
- [ ] Run `molecule test -s plugins` — module tests should still pass