### PR TITLE
Remove ansible_facts dependency from cert generation

### DIFF
--- a/roles/elasticsearch/tasks/elasticsearch-security.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-security.yml
@@ -404,7 +404,7 @@
             - certificates
             - renew_es_cert
       vars:
-        _cert_path: "/etc/elasticsearch/certs/{{ ansible_facts.hostname }}.p12"
+        _cert_path: "/etc/elasticsearch/certs/{{ inventory_hostname_short }}.p12"
         _cert_pass: "{{ elasticsearch_tls_key_passphrase }}"
         _cert_buffer_days: "{{ elasticsearch_cert_expiration_buffer }}"
         _cert_expiry_fact: elasticsearch_cert_will_expire_soon
@@ -437,7 +437,7 @@
             - renew_ca
             - renew_es_cert
       vars:
-        _backup_path: "{{ elasticstack_ca_dir }}/{{ ansible_facts.hostname }}.p12"
+        _backup_path: "{{ elasticstack_ca_dir }}/{{ inventory_hostname_short }}.p12"
         _backup_target: "{{ elasticstack_ca_host }}"
       when: "'renew_es_cert' in ansible_run_tags or 'renew_ca' in ansible_run_tags or elasticsearch_cert_will_expire_soon | bool"
       tags:
@@ -453,7 +453,7 @@
             - renew_ca
             - renew_es_cert
       vars:
-        _backup_path: "{{ lookup('config', 'DEFAULT_LOCAL_TMP') | dirname }}/certs/{{ inventory_hostname }}/{{ ansible_facts.hostname }}.p12"
+        _backup_path: "{{ lookup('config', 'DEFAULT_LOCAL_TMP') | dirname }}/certs/{{ inventory_hostname }}/{{ inventory_hostname_short }}.p12"
         _backup_target: localhost
         _backup_become: false
       when: "'renew_es_cert' in ansible_run_tags or 'renew_ca' in ansible_run_tags or elasticsearch_cert_will_expire_soon | bool"
@@ -490,10 +490,10 @@
             - renew_ca
             - renew_es_cert
       vars:
-        _cert_name: "{{ hostvars[item].ansible_facts.hostname }}"
-        _cert_ip: "{{ hostvars[item].ansible_facts.default_ipv4.address | default(hostvars[item].ansible_facts.all_ipv4_addresses[0]) }}"
-        _cert_dns: "{{ hostvars[item].ansible_facts.hostname }},{{ hostvars[item].ansible_facts.fqdn }},{{ hostvars[item].inventory_hostname }}"
-        _cert_out: "{{ elasticstack_ca_dir }}/{{ hostvars[item].ansible_facts.hostname }}.p12"
+        _cert_name: "{{ hostvars[item].inventory_hostname_short }}"
+        _cert_ip: "{{ hostvars[item].ansible_host | default(hostvars[item].inventory_hostname) }}"
+        _cert_dns: "{{ hostvars[item].inventory_hostname_short }},{{ hostvars[item].inventory_hostname }}"
+        _cert_out: "{{ elasticstack_ca_dir }}/{{ hostvars[item].inventory_hostname_short }}.p12"
         _cert_pass: "{{ (hostvars[item].elasticsearch_tls_key_passphrase is defined) | ternary(hostvars[item].elasticsearch_tls_key_passphrase, elasticsearch_tls_key_passphrase) }}"
         _cert_validity: "{{ elasticsearch_cert_validity_period }}"
       loop: "{{ groups[elasticstack_elasticsearch_group_name] }}"
@@ -512,7 +512,7 @@
             - certificates
             - renew_ca
       vars:
-        _cert_p12_path: "{{ elasticstack_ca_dir }}/{{ ansible_facts.hostname }}.p12"
+        _cert_p12_path: "{{ elasticstack_ca_dir }}/{{ inventory_hostname_short }}.p12"
         _cert_ca_out: "{{ elasticstack_ca_dir }}/ca.crt"
         _cert_pass: "{{ elasticsearch_tls_key_passphrase }}"
       when: inventory_hostname == elasticstack_ca_host
@@ -566,8 +566,8 @@
             - renew_ca
             - renew_es_cert
       vars:
-        _cert_src: "{{ elasticstack_ca_dir }}/{{ ansible_facts.hostname }}.p12"
-        _cert_dest: "/etc/elasticsearch/certs/{{ ansible_facts.hostname }}.p12"
+        _cert_src: "{{ elasticstack_ca_dir }}/{{ inventory_hostname_short }}.p12"
+        _cert_dest: "/etc/elasticsearch/certs/{{ inventory_hostname_short }}.p12"
         _cert_owner: root
         _cert_group: elasticsearch
         _cert_mode: "0640"
@@ -778,7 +778,7 @@
       {{ '/etc/elasticsearch/certs/' ~ inventory_hostname ~ '-transport'
          ~ ('.p12' if (_elasticsearch_transport_cert_format | default('')) == 'p12' else '.crt')
          if elasticsearch_cert_source == 'external'
-         else '/etc/elasticsearch/certs/' ~ ansible_facts.hostname ~ '.p12' }}
+         else '/etc/elasticsearch/certs/' ~ inventory_hostname_short ~ '.p12' }}
     _warn_cert_pass: >-
       {{ elasticsearch_transport_tls_key_passphrase
          if elasticsearch_cert_source == 'external'
@@ -799,7 +799,7 @@
       {{ '/etc/elasticsearch/certs/' ~ inventory_hostname ~ '-http'
          ~ ('.p12' if (_elasticsearch_http_cert_format | default('')) == 'p12' else '.crt')
          if elasticsearch_cert_source == 'external'
-         else '/etc/elasticsearch/certs/' ~ ansible_facts.hostname ~ '.p12' }}
+         else '/etc/elasticsearch/certs/' ~ inventory_hostname_short ~ '.p12' }}
     _warn_cert_pass: >-
       {{ _elasticsearch_effective_http_pass | default(elasticsearch_transport_tls_key_passphrase)
          if elasticsearch_cert_source == 'external'

--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -36,7 +36,7 @@ discovery.seed_hosts: {{ elasticsearch_seed_hosts | to_json }}
 {% else %}
 {% if groups[elasticstack_elasticsearch_group_name] | length > 1 %}
 discovery.seed_hosts: [ {% for host in groups[elasticstack_elasticsearch_group_name]  %}
-"{{ hostvars[host].ansible_facts.default_ipv4.address | default(hostvars[host].ansible_facts.all_ipv4_addresses[0]) }}"{% if not loop.last %},{% endif %}
+"{{ hostvars[host].ansible_host | default(hostvars[host].inventory_hostname) }}"{% if not loop.last %},{% endif %}
 {% endfor %} ]
 {% endif %}
 {% endif %}
@@ -76,8 +76,8 @@ xpack.security.transport.ssl.keystore.path: certs/{{ inventory_hostname }}-trans
 xpack.security.transport.ssl.truststore.path: certs/{{ inventory_hostname }}-transport.p12
 {%   endif %}
 {% else %}
-xpack.security.transport.ssl.keystore.path: certs/{{ ansible_facts.hostname }}.p12
-xpack.security.transport.ssl.truststore.path: certs/{{ ansible_facts.hostname }}.p12
+xpack.security.transport.ssl.keystore.path: certs/{{ inventory_hostname_short }}.p12
+xpack.security.transport.ssl.truststore.path: certs/{{ inventory_hostname_short }}.p12
 {% endif %}
 {% if elasticsearch_http_security | bool %}
 xpack.security.http.ssl.enabled: true
@@ -96,9 +96,9 @@ xpack.security.http.ssl.truststore.path: certs/{{ inventory_hostname }}-http.p12
 {% if elasticsearch_http_ssl_keystore_path | default('', true) | length > 0 %}
 xpack.security.http.ssl.keystore.path: {{ elasticsearch_http_ssl_keystore_path }}
 {% else %}
-xpack.security.http.ssl.keystore.path: certs/{{ ansible_facts.hostname }}.p12
+xpack.security.http.ssl.keystore.path: certs/{{ inventory_hostname_short }}.p12
 {% endif %}
-xpack.security.http.ssl.truststore.path: certs/{{ ansible_facts.hostname }}.p12
+xpack.security.http.ssl.truststore.path: certs/{{ inventory_hostname_short }}.p12
 {% endif %}
 {% endif %}
 {% endif %}

--- a/roles/logstash/tasks/logstash-security.yml
+++ b/roles/logstash/tasks/logstash-security.yml
@@ -291,7 +291,7 @@
           - names: "{{ logstash_role_indicies_names }}"
             privileges: "{{ logstash_role_indicies_privileges }}"
         state: present
-        host: "https://{{ hostvars[elasticstack_ca_host].ansible_facts.default_ipv4.address }}:{{ elasticstack_elasticsearch_http_port }}"
+        host: "https://{{ hostvars[elasticstack_ca_host].ansible_host | default(hostvars[elasticstack_ca_host].inventory_hostname) }}:{{ elasticstack_elasticsearch_http_port }}"
         auth_user: elastic
         auth_pass: "{{ _logstash_elastic_password.stdout }}"
         verify_certs: true
@@ -308,7 +308,7 @@
           - "{{ logstash_role_name }}"
         enabled: true
         state: present
-        host: "https://{{ hostvars[elasticstack_ca_host].ansible_facts.default_ipv4.address }}:{{ elasticstack_elasticsearch_http_port }}"
+        host: "https://{{ hostvars[elasticstack_ca_host].ansible_host | default(hostvars[elasticstack_ca_host].inventory_hostname) }}:{{ elasticstack_elasticsearch_http_port }}"
         auth_user: elastic
         auth_pass: "{{ _logstash_elastic_password.stdout }}"
         verify_certs: true


### PR DESCRIPTION
## Summary
- Replace all `hostvars[].ansible_facts.hostname`, `.fqdn`, `.default_ipv4.address` references with inventory-based equivalents (`inventory_hostname`, `inventory_hostname_short`, `ansible_host`)
- Certificate generation, `elasticsearch.yml` seed_hosts fallback, `instances.j2` template, and logstash security tasks no longer require gathered facts from remote hosts

Closes #22

## Problem
When generating certificates on the CA host, the role iterates over all elasticsearch nodes and accesses `hostvars[item].ansible_facts.hostname`. If any node is unreachable (SSH issues, initial deploy, `--limit`), `ansible_facts` is an empty dict and the task fails with a cryptic `object of type 'dict' has no attribute 'hostname'` error.

## Solution
Use Ansible inventory variables that are always available:
- `inventory_hostname_short` instead of `ansible_facts.hostname`
- `inventory_hostname` instead of `ansible_facts.fqdn`
- `ansible_host | default(inventory_hostname)` instead of `ansible_facts.default_ipv4.address`

Cert generation now works regardless of host reachability. Certs are generated for all nodes; distribution to unreachable nodes simply fails with a clear SSH error, and can be completed later with `--limit`.

## Changed files
- `roles/elasticsearch/tasks/elasticsearch-security.yml` — cert vars
- `roles/elasticsearch/templates/elasticsearch.yml.j2` — seed_hosts fallback + TLS paths
- `roles/elasticsearch/templates/instances.j2` — IP and DNS entries
- `roles/logstash/tasks/logstash-security.yml` — CA host address for API calls

## Test plan
- [ ] Deploy fresh cluster with all nodes reachable — certs generated with correct names
- [ ] Deploy with some nodes unreachable — certs generated, distribution fails gracefully
- [ ] Verify `elasticsearch.yml` has correct keystore paths using short hostname
- [ ] Verify cert SANs include both short hostname and FQDN