### PR TITLE
Reduce CI redundancy in molecule test matrix

### DIFF
--- a/.gitea/workflows/test_full_stack.yml
+++ b/.gitea/workflows/test_full_stack.yml
@@ -13,6 +13,15 @@ on:
           - warning
           - debug
   pull_request:
+    paths:
+      - 'roles/**'
+      - 'molecule/elasticstack_*/**'
+      - 'molecule/es_kibana/**'
+      - 'molecule/logstash_elasticsearch/**'
+      - 'molecule/cert_renewal/**'
+      - 'molecule/shared/**'
+      - 'plugins/**'
+      - '.gitea/workflows/test_full_stack.yml'
   merge_group:
   schedule:
     - cron: "0 4 * * *"

--- a/.gitea/workflows/test_role_logstash.yml
+++ b/.gitea/workflows/test_role_logstash.yml
@@ -54,7 +54,6 @@ jobs:
           - debian12
           - debian13
         scenario:
-          - logstash_default
           - logstash_ssl
           - logstash_custom_pipeline
           - logstash_advanced

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -13,6 +13,15 @@ on:
           - warning
           - debug
   pull_request:
+    paths:
+      - 'roles/**'
+      - 'molecule/elasticstack_*/**'
+      - 'molecule/es_kibana/**'
+      - 'molecule/logstash_elasticsearch/**'
+      - 'molecule/cert_renewal/**'
+      - 'molecule/shared/**'
+      - 'plugins/**'
+      - '.github/workflows/test_full_stack.yml'
   merge_group:
   schedule:
     - cron: "0 4 * * *"

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -63,7 +63,6 @@ jobs:
       matrix:
         distro: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && fromJSON('["rockylinux10","debian13"]') || fromJSON('["rockylinux9","rockylinux10","ubuntu2204","ubuntu2404","debian11","debian12","debian13"]') }}
         scenario:
-          - logstash_default
           - logstash_ssl
           - logstash_custom_pipeline
           - logstash_advanced


### PR DESCRIPTION
The full-stack workflow had no path filter on pull_request, so every PR — even documentation-only changes — triggered 24 molecule jobs. Added path filters covering all roles, molecule scenarios, plugins, and shared files. The nightly schedule still runs the full matrix unconditionally.

Also removed logstash_default from the logstash role workflow. The logstash_advanced scenario is a strict superset that tests everything default does (template pipeline, grok filter, ident mutate, pipeline identifier, queue settings, autoreload, port 5044) plus plugins, filter files, extra inputs, config backup, and log4j2 rendering. This saves 14 nightly jobs with zero coverage loss.

Both changes applied to .github/ and .gitea/ workflow copies.

Closes #32