### PR TITLE
Remove duplicate apt cache updates from service roles

### DIFF
--- a/roles/beats/tasks/main.yml
+++ b/roles/beats/tasks/main.yml
@@ -5,13 +5,6 @@
     name: oddly.elasticstack.elasticstack
   when: not hostvars[inventory_hostname]._elasticstack_role_imported | default(false)
 
-- name: Update apt cache.
-  ansible.builtin.apt:
-    update_cache: true
-    cache_valid_time: 600
-  changed_when: false
-  when: ansible_facts.os_family == 'Debian'
-
 - name: Prepare for whole stack roles if used
   when:
     - elasticstack_full_stack | bool

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -22,13 +22,6 @@
     name: oddly.elasticstack.elasticstack
   when: not hostvars[inventory_hostname]._elasticstack_role_imported | default(false)
 
-- name: Update apt cache.
-  ansible.builtin.apt:
-    update_cache: true
-    cache_valid_time: 600
-  changed_when: false
-  when: ansible_facts.os_family == 'Debian'
-
 - name: Check-set-parameters
   ansible.builtin.include_tasks: elasticsearch-parameters.yml
 

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -5,13 +5,6 @@
     name: oddly.elasticstack.elasticstack
   when: not hostvars[inventory_hostname]._elasticstack_role_imported | default(false)
 
-- name: Update apt cache.
-  ansible.builtin.apt:
-    update_cache: true
-    cache_valid_time: 600
-  changed_when: false
-  when: ansible_facts.os_family == 'Debian'
-
 - name: Set common password for common certificates
   ansible.builtin.set_fact:
     kibana_tls_key_passphrase: "{{ elasticstack_cert_pass }}"

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -29,13 +29,6 @@
     name: oddly.elasticstack.elasticstack
   when: not hostvars[inventory_hostname]._elasticstack_role_imported | default(false)
 
-- name: Update apt cache
-  ansible.builtin.apt:
-    update_cache: true
-    cache_valid_time: 600
-  changed_when: false
-  when: ansible_facts.os_family == 'Debian'
-
 - name: Set up Elasticsearch hosts from inventory
   ansible.builtin.set_fact:
     _logstash_es_hosts: "{{ logstash_elasticsearch_hosts }}"


### PR DESCRIPTION
Every service role duplicated an identical `apt: update_cache: true, cache_valid_time: 600` task that already runs in the shared elasticstack role's `packages.yml`. Since every service role imports the shared role first and `cache_valid_time: 600` makes subsequent updates no-ops within that window, the per-role copies were always redundant noise.

This is the first step for #34. The package install consolidation, wait-for-port dedup, and cert detection dedup from that issue are more involved and will come in follow-up PRs.

Partial fix for #34