### PR TITLE
Simplify list serialization in elasticsearch.yml.j2

### DIFF
--- a/roles/elasticsearch/templates/elasticsearch.yml.j2
+++ b/roles/elasticsearch/templates/elasticsearch.yml.j2
@@ -27,7 +27,7 @@ http.publish_port: {{ elasticsearch_http_publish_port }}
 {% endif %}
 
 {% if elasticsearch_node_types is defined %}
-node.roles: [ {% for type in elasticsearch_node_types %}{{ type }}{% if not loop.last %}, {% endif %}{% endfor %} ]
+node.roles: {{ elasticsearch_node_types | to_json }}
 {% endif %}
 
 {% if groups[elasticstack_elasticsearch_group_name] | length == 1 %}


### PR DESCRIPTION
Replaced the manual for-loop with comma handling for `node.roles` with `| to_json`. The loop-based approach is fragile and harder to read than letting Jinja2 serialize the list directly. The `discovery.seed_hosts` and `cluster.initial_master_nodes` loops were left alone since they do hostvars lookups that don't simplify with filter chains.

The larger items from #35 (beats output block dedup, logstash SSL pre-computation, template-to-task logic migration) are more invasive and left for follow-up work.

Partial fix for #35