### PR TITLE
Remove dead variables from role defaults and tasks

### DIFF
--- a/roles/elasticstack/tasks/main.yml
+++ b/roles/elasticstack/tasks/main.yml
@@ -55,10 +55,6 @@
     - name: Fetch passwords if passwords are initialized
       ansible.builtin.import_tasks: elasticstack-passwords.yml
 
-    - name: Set elasticstack_globals_set for other roles to skip this role
-      ansible.builtin.set_fact:
-        elasticstack_globals_set: true
-
     - name: Install common packages and dependencies
       ansible.builtin.import_tasks: packages.yml
 

--- a/roles/kibana/defaults/main.yml
+++ b/roles/kibana/defaults/main.yml
@@ -25,10 +25,6 @@ kibana_manage_yaml: true
 kibana_security: true
 # @var kibana_tls:description: Enable TLS on the Kibana web interface itself (serve Kibana over HTTPS)
 kibana_tls: false
-# @var kibana_tls_cert:description: Path to the TLS certificate file for the Kibana web interface
-kibana_tls_cert: /etc/kibana/certs/cert.pem
-# @var kibana_tls_key:description: Path to the TLS private key file for the Kibana web interface
-kibana_tls_key: /etc/kibana/certs/key.pem
 # @var kibana_tls_key_passphrase:description: Passphrase for the Kibana TLS private key
 kibana_tls_key_passphrase: PleaseChangeMe
 # @var kibana_keystore_password:description: Password to encrypt the Kibana keystore file. Empty means no encryption (same as ES default)


### PR DESCRIPTION
Removed two dead variables found during the codebase audit. kibana_tls_cert and kibana_tls_key in kibana defaults were hardcoded path placeholders never referenced in any task or template — the actual cert paths are computed dynamically from inventory_hostname and certificate format. The elasticstack_globals_set set_fact in the shared role was set but never checked anywhere; the actual import guard is _elasticstack_role_imported.

The bigger items from #36 (adding missing defaults for elasticsearch_extra_config et al, relocating freshstart sentinels to vars/, naming consistency fixes) need more careful analysis since they could change behavior for users relying on `is defined` checks.

Partial fix for #36