### PR TITLE
Replace bare ansible_date_time with ansible_facts.date_time

### DIFF
--- a/molecule/elasticsearch_upgrade_8to9/converge.yml
+++ b/molecule/elasticsearch_upgrade_8to9/converge.yml
@@ -90,7 +90,7 @@
         body_format: json
         body:
           test_field: "pre-upgrade-data"
-          timestamp: "{{ ansible_date_time.iso8601 }}"
+          timestamp: "{{ ansible_facts.date_time.iso8601 }}"
         validate_certs: false
         status_code: [200, 201]
       register: index_result

--- a/molecule/plugins/converge.yml
+++ b/molecule/plugins/converge.yml
@@ -27,7 +27,7 @@
     - name: Debug with to_datetime() - strip timezone for naive datetime arithmetic
       ansible.builtin.debug:
         msg: >-
-          "{{ ((test.not_valid_after | regex_replace('[+-]\d{2}:\d{2}$', '') | to_datetime('%Y-%m-%d %H:%M:%S')) - (ansible_date_time.date | to_datetime('%Y-%m-%d'))).days }}"
+          "{{ ((test.not_valid_after | regex_replace('[+-]\d{2}:\d{2}$', '') | to_datetime('%Y-%m-%d %H:%M:%S')) - (ansible_facts.date_time.date | to_datetime('%Y-%m-%d'))).days }}"
     - name: Test wrong passphrase
       oddly.elasticstack.cert_info:
         path: files/es-ca/elastic-stack-ca.p12

--- a/roles/elasticstack/tasks/certs/cert_backup.yml
+++ b/roles/elasticstack/tasks/certs/cert_backup.yml
@@ -19,7 +19,7 @@
 - name: "Create timestamped backup - {{ _backup_path }}"
   ansible.builtin.copy:
     src: "{{ _backup_path }}"
-    dest: "{{ _backup_path }}_{{ ansible_date_time.iso8601_micro }}"
+    dest: "{{ _backup_path }}_{{ ansible_facts.date_time.iso8601_micro }}"
     mode: preserve
     remote_src: "{{ _backup_target != 'localhost' }}"
   when: elasticstack_backup_stat.stat.exists

--- a/roles/elasticstack/tasks/certs/cert_check_expiry.yml
+++ b/roles/elasticstack/tasks/certs/cert_check_expiry.yml
@@ -35,7 +35,7 @@
       ansible.builtin.set_fact:
         "{{ _cert_days_fact | default('elasticstack_cert_expiration_days') }}": >-
           {{ (((elasticstack_cert_info.not_valid_after | regex_replace('[+-]\d{2}:\d{2}$', ''))
-          | to_datetime('%Y-%m-%d %H:%M:%S')) - (ansible_date_time.date
+          | to_datetime('%Y-%m-%d %H:%M:%S')) - (ansible_facts.date_time.date
           | to_datetime('%Y-%m-%d'))).days }}
 
     - name: "Set certificate expiry fact - {{ _cert_expiry_fact }}"

--- a/roles/elasticstack/tasks/certs/cert_expiry_warn.yml
+++ b/roles/elasticstack/tasks/certs/cert_expiry_warn.yml
@@ -31,7 +31,7 @@
       ansible.builtin.set_fact:
         _warn_days_remaining: >-
           {{ ((((_warn_cert_result.not_valid_after | regex_replace('[+-]\d{2}:\d{2}$', ''))
-          | to_datetime('%Y-%m-%d %H:%M:%S')) - (ansible_date_time.date
+          | to_datetime('%Y-%m-%d %H:%M:%S')) - (ansible_facts.date_time.date
           | to_datetime('%Y-%m-%d'))).days) }}
       when: _warn_cert_result is succeeded
 


### PR DESCRIPTION
Closes #44.

Ansible 2.20 already emits INJECT_FACTS_AS_VARS deprecation warnings for bare fact access like `ansible_date_time.date`, and Ansible 2.24 will remove the legacy injection entirely. Three role task files (cert_backup, cert_check_expiry, cert_expiry_warn) and two molecule converge files used the bare form. This replaces all occurrences with `ansible_facts.date_time.*`, matching the style already used everywhere else in the codebase.