### PR TITLE
Add ansible_managed header to all templates

### DIFF
--- a/roles/beats/templates/auditbeat.yml.j2
+++ b/roles/beats/templates/auditbeat.yml.j2
@@ -1,3 +1,5 @@
+{{ ansible_managed | comment }}
+
 auditbeat.modules:
 - module: auditd
   audit_rule_files: [ '${path.config}/audit.rules.d/*.conf' ]

--- a/roles/beats/templates/filebeat-system.yml.j2
+++ b/roles/beats/templates/filebeat-system.yml.j2
@@ -1,3 +1,5 @@
+{{ ansible_managed | comment }}
+
 - module: system
   syslog:
     enabled: true

--- a/roles/beats/templates/filebeat.yml.j2
+++ b/roles/beats/templates/filebeat.yml.j2
@@ -1,3 +1,5 @@
+{{ ansible_managed | comment }}
+
 filebeat.inputs:
 
 {% if beats_filebeat_log_input | bool %}

--- a/roles/beats/templates/metricbeat.yml.j2
+++ b/roles/beats/templates/metricbeat.yml.j2
@@ -1,4 +1,6 @@
 ---
+{{ ansible_managed | comment }}
+
 metricbeat.config.modules:
   path: ${path.config}/modules.d/*.yml
   reload.enabled: false

--- a/roles/kibana/templates/kibana.yml.j2
+++ b/roles/kibana/templates/kibana.yml.j2
@@ -1,3 +1,5 @@
+{{ ansible_managed | comment }}
+
 server.host: "0.0.0.0"
 server.publicBaseUrl: "http{% if kibana_tls | bool %}s{% endif %}://{{ elasticstack_kibana_host | default( ansible_facts.fqdn ) }}:{{ elasticstack_kibana_port }}"
 {% if kibana_server_protocol is defined and kibana_server_protocol | length > 0 %}

--- a/roles/logstash/templates/10-input.conf.j2
+++ b/roles/logstash/templates/10-input.conf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 input {
 {% if logstash_input_beats | default(true) | bool %}
   beats {

--- a/roles/logstash/templates/50-filter.conf.j2
+++ b/roles/logstash/templates/50-filter.conf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 {% if logstash_filters | default('') | length > 0 or logstash_filter_files | default([]) | length > 0 %}
 filter {
 {% if logstash_ident | default(true) | bool %}

--- a/roles/logstash/templates/90-output.conf.j2
+++ b/roles/logstash/templates/90-output.conf.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 output {
 {% if logstash_output_elasticsearch | default(true) | bool %}
   elasticsearch {

--- a/roles/logstash/templates/custom-pipeline.conf.j2
+++ b/roles/logstash/templates/custom-pipeline.conf.j2
@@ -1,1 +1,3 @@
+# {{ ansible_managed }}
+
 {{ logstash_custom_pipeline }}

--- a/roles/logstash/templates/log4j2.properties.j2
+++ b/roles/logstash/templates/log4j2.properties.j2
@@ -1,5 +1,4 @@
-# Managed by Ansible Role
-# https://github.com/netways/ansible-role-logstash
+# {{ ansible_managed }}
 #
 # Logging to logfile: {% if logstash_logging_file | bool %}true{% else %}false{% endif %}
 

--- a/roles/logstash/templates/logstash.yml.j2
+++ b/roles/logstash/templates/logstash.yml.j2
@@ -1,3 +1,5 @@
+{{ ansible_managed | comment }}
+
 path.data: {{ logstash_config_path_data }}
 config.reload.automatic: {{ logstash_config_autoreload | lower }}
 {% if logstash_config_autoreload | bool and logstash_config_autoreload_interval is defined %}

--- a/roles/logstash/templates/pipelines.yml.j2
+++ b/roles/logstash/templates/pipelines.yml.j2
@@ -1,4 +1,6 @@
 ---
+{{ ansible_managed | comment }}
+
 - pipeline.id: main
   path.config: "/etc/logstash/conf.d/main/*.conf"
   queue.type: {{ logstash_queue_type }}


### PR DESCRIPTION
Closes #43.

Twelve templates across beats, kibana, and logstash roles were missing the `ansible_managed` comment header that marks files as Ansible-managed on target hosts. YAML templates get `{{ ansible_managed | comment }}`, conf and properties files get `# {{ ansible_managed }}`. The logstash log4j2.properties.j2 had a stale static "Managed by Ansible Role" header from the original netways fork that was replaced with the standard Ansible-managed marker.