### PR TITLE
Add retry logic to early-stage package installs

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -118,6 +118,10 @@
 - name: Install openssl if security is activated
   ansible.builtin.package:
     name: openssl
+  register: _openssl_install
+  until: _openssl_install is success
+  retries: 3
+  delay: 10
   when: elasticsearch_security | bool
 
 # the following should be done by the rpm but failed with 7.4

--- a/roles/elasticstack/tasks/packages.yml
+++ b/roles/elasticstack/tasks/packages.yml
@@ -20,6 +20,10 @@
       - python3-cryptography
       - python3-packaging
       - openssl
+  register: _security_packages_install
+  until: _security_packages_install is success
+  retries: 3
+  delay: 10
   tags:
     - certificates
     - renew_ca

--- a/roles/repos/tasks/debian.yml
+++ b/roles/repos/tasks/debian.yml
@@ -5,12 +5,20 @@
       - gpg
       - gpg-agent
     state: present
+  register: _gpg_install_deb
+  until: _gpg_install_deb is success
+  retries: 3
+  delay: 10
 
 - name: Ensure Elastic Stack key is available (Debian)
   ansible.builtin.get_url:
     url: "{{ elasticstack_repo_key }}"
     dest: /usr/share/keyrings/elasticsearch.asc
     mode: "0644"
+  register: _elastic_key_download
+  until: _elastic_key_download is success
+  retries: 3
+  delay: 10
 
 - name: Ensure Elastic Stack apt repo is absent (Debian legacy format)
   ansible.builtin.file:

--- a/roles/repos/tasks/redhat.yml
+++ b/roles/repos/tasks/redhat.yml
@@ -7,6 +7,10 @@
   ansible.builtin.package:
     name: gnupg
     state: present
+  register: _gpg_install_rh
+  until: _gpg_install_rh is success
+  retries: 3
+  delay: 10
 
 - name: Workaround for EL > 8
   when:
@@ -27,6 +31,10 @@
         - name: Install crypto-policies-scripts
           ansible.builtin.package:
             name: crypto-policies-scripts
+          register: _crypto_policies_install
+          until: _crypto_policies_install is success
+          retries: 3
+          delay: 10
 
         # since we don't expect to have that workaround for long
         # we can skip having idempotency checks fixed


### PR DESCRIPTION
Closes #46.

The main service package installs already have retry logic, but six early-stage tasks did not: GPG key download (get_url), gpg package installs on Debian and RHEL, crypto-policies-scripts, openssl, and the security prerequisite packages. These are vulnerable to transient network issues or package manager lock contention, especially in CI where multiple containers share the same cache. Added the same retries: 3 / delay: 10 / until: success pattern already used by the service installs.