### PR TITLE
Guard URI retry loops against missing .json attribute

### DIFF
--- a/roles/elasticsearch/tasks/elasticsearch-rolling-upgrade.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-rolling-upgrade.yml
@@ -103,7 +103,7 @@
         validate_certs: "{{ elasticsearch_validate_api_certs }}"
         force_basic_auth: true
       register: elasticsearch_response
-      until: elasticsearch_response.json.acknowledged | default(false)
+      until: (elasticsearch_response.json | default({})).acknowledged | default(false)
       retries: 10
       delay: 30
       no_log: "{{ elasticstack_no_log }}"
@@ -119,7 +119,7 @@
         validate_certs: "{{ elasticsearch_validate_api_certs }}"
         force_basic_auth: true
       register: elasticsearch_response
-      until: (elasticsearch_response.json.status | default('')) in ['green', 'yellow']
+      until: ((elasticsearch_response.json | default({})).status | default('')) in ['green', 'yellow']
       retries: 50
       delay: 30
       no_log: "{{ elasticstack_no_log }}"
@@ -137,7 +137,7 @@
         validate_certs: "{{ elasticsearch_validate_api_certs }}"
         force_basic_auth: true
       register: elasticsearch_response
-      until: elasticsearch_response.json.acknowledged | default(false)
+      until: (elasticsearch_response.json | default({})).acknowledged | default(false)
       retries: 5
       delay: 10
       no_log: "{{ elasticstack_no_log }}"
@@ -235,7 +235,7 @@
         validate_certs: "{{ elasticsearch_validate_api_certs }}"
         force_basic_auth: true
       register: elasticsearch_response
-      until: elasticsearch_response.json.acknowledged | default(false)
+      until: (elasticsearch_response.json | default({})).acknowledged | default(false)
       retries: 5
       delay: 30
       no_log: "{{ elasticstack_no_log }}"
@@ -249,7 +249,7 @@
         validate_certs: "{{ elasticsearch_validate_api_certs }}"
         force_basic_auth: true
       register: elasticsearch_response
-      until: (elasticsearch_response.json.status | default('')) in ['green', 'yellow']
+      until: ((elasticsearch_response.json | default({})).status | default('')) in ['green', 'yellow']
       retries: 30
       delay: 30
       no_log: "{{ elasticstack_no_log }}"

--- a/roles/elasticsearch/tasks/elasticsearch-security.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-security.yml
@@ -675,7 +675,7 @@
       no_log: "{{ elasticstack_no_log }}"
       when:
         - not elasticsearch_passwords_file.stat.exists | bool
-      until: elasticsearch_api_status_bootstrap.json.cluster_name is defined
+      until: (elasticsearch_api_status_bootstrap.json | default({})).cluster_name is defined
       retries: 30
       delay: 10
 
@@ -694,7 +694,7 @@
       no_log: "{{ elasticstack_no_log }}"
       when:
         - not elasticsearch_passwords_file.stat.exists | bool
-      until: elasticsearch_cluster_status_bootstrap.json.status in ["green", "yellow"]
+      until: (elasticsearch_cluster_status_bootstrap.json | default({})).status | default('') in ["green", "yellow"]
       retries: 30
       delay: 10
 
@@ -718,7 +718,7 @@
       no_log: "{{ elasticstack_no_log }}"
       when:
         - elasticsearch_passwords_file.stat.exists | bool
-      until: elasticsearch_api_status.json.cluster_name is defined
+      until: (elasticsearch_api_status.json | default({})).cluster_name is defined
       retries: 20
       delay: 10
 
@@ -768,7 +768,7 @@
       no_log: "{{ elasticstack_no_log }}"
       when:
         - elasticsearch_passwords_file.stat.exists | bool
-      until: (elasticsearch_cluster_status.json.status | default('')) in ['green', 'yellow']
+      until: ((elasticsearch_cluster_status.json | default({})).status | default('')) in ['green', 'yellow']
       retries: 20
       delay: 10
 

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -471,7 +471,7 @@
         url: "http://{{ elasticsearch_api_host }}:{{ elasticstack_elasticsearch_http_port }}/_cluster/health?pretty"
       register: elasticsearch_cluster_status
       ignore_errors: "{{ ansible_check_mode }}"
-      until: (elasticsearch_cluster_status.json.status | default('')) in ['green', 'yellow']
+      until: ((elasticsearch_cluster_status.json | default({})).status | default('')) in ['green', 'yellow']
       retries: 30
       delay: 10
       no_log: "{{ elasticstack_no_log }}"


### PR DESCRIPTION
When the URI module returns an error response (connection refused, 401, 503, etc.), the registered variable has no `.json` attribute. The `until` condition then crashes with `dict object has no attribute 'json'` instead of retrying, which is the whole point of the retry loop.

This wraps all `.json` accesses in `until` conditions with `| default({})` so the outer attribute lookup returns an empty dict on error responses. The existing `| default('')` or `| default(false)` guards on the inner key then do their job and the retry loop continues as expected.

Affected files:
- `elasticsearch-security.yml` — 4 `until` conditions (API availability checks, cluster status checks)
- `elasticsearch-rolling-upgrade.yml` — 5 `until` conditions (shard allocation acknowledged, cluster health)
- `main.yml` — 1 `until` condition (cluster status without security)

Fixes #52