### PR TITLE
Fix changed_when on keystore and crypto-policy tasks

### DIFF
--- a/roles/elasticsearch/tasks/elasticsearch-keystore.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-keystore.yml
@@ -19,14 +19,27 @@
   notify:
     - Restart Elasticsearch
 
+- name: Get current bootstrap password
+  ansible.builtin.command: >
+    /usr/share/elasticsearch/bin/elasticsearch-keystore
+    show bootstrap.password
+  when: "'bootstrap.password' in elasticsearch_keystore.stdout_lines"
+  register: elasticsearch_current_bootstrap_pw
+  changed_when: false
+  no_log: true
+  ignore_errors: "{{ ansible_check_mode }}"
+
 - name: Set bootstrap password
   ansible.builtin.command: >
     /usr/share/elasticsearch/bin/elasticsearch-keystore
     add -x -f 'bootstrap.password'
   args:
     stdin: "{{ elasticsearch_bootstrap_pw }}"
-  changed_when: false
+  changed_when: true
   no_log: true
+  when: >-
+    elasticsearch_current_bootstrap_pw.stdout is undefined or
+    elasticsearch_current_bootstrap_pw.stdout != elasticsearch_bootstrap_pw
   notify:
     - Restart Elasticsearch
   ignore_errors: "{{ ansible_check_mode }}"
@@ -58,7 +71,7 @@
       {{ (elasticsearch_http_tls_key_passphrase | default(elasticsearch_transport_tls_key_passphrase, true))
          if elasticsearch_cert_source == 'external'
          else elasticsearch_tls_key_passphrase }}
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - elasticsearch_http_security
@@ -75,7 +88,7 @@
   ansible.builtin.command: >
     /usr/share/elasticsearch/bin/elasticsearch-keystore
     remove xpack.security.http.ssl.keystore.secure_password
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - "'xpack.security.http.ssl.keystore.secure_password' in elasticsearch_keystore.stdout_lines"
@@ -105,7 +118,7 @@
       {{ (elasticsearch_http_tls_key_passphrase | default(elasticsearch_transport_tls_key_passphrase, true))
          if elasticsearch_cert_source == 'external'
          else elasticsearch_tls_key_passphrase }}
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - elasticsearch_http_security
@@ -122,7 +135,7 @@
   ansible.builtin.command: >
     /usr/share/elasticsearch/bin/elasticsearch-keystore
     remove xpack.security.http.ssl.truststore.secure_password
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - "'xpack.security.http.ssl.truststore.secure_password' in elasticsearch_keystore.stdout_lines"
@@ -154,7 +167,7 @@
       {{ elasticsearch_transport_tls_key_passphrase
          if elasticsearch_cert_source == 'external'
          else elasticsearch_tls_key_passphrase }}
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - elasticsearch_security
@@ -171,7 +184,7 @@
   ansible.builtin.command: >
     /usr/share/elasticsearch/bin/elasticsearch-keystore
     remove xpack.security.transport.ssl.keystore.secure_password
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - "'xpack.security.transport.ssl.keystore.secure_password' in elasticsearch_keystore.stdout_lines"
@@ -201,7 +214,7 @@
       {{ elasticsearch_transport_tls_key_passphrase
          if elasticsearch_cert_source == 'external'
          else elasticsearch_tls_key_passphrase }}
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - elasticsearch_security
@@ -218,7 +231,7 @@
   ansible.builtin.command: >
     /usr/share/elasticsearch/bin/elasticsearch-keystore
     remove xpack.security.transport.ssl.truststore.secure_password
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - "'xpack.security.transport.ssl.truststore.secure_password' in elasticsearch_keystore.stdout_lines"
@@ -228,20 +241,50 @@
 
 # --- PEM key passphrase in keystore for external PEM certs ---
 
+- name: Get xpack.security.transport.ssl.secure_key_passphrase
+  ansible.builtin.command: >
+    /usr/share/elasticsearch/bin/elasticsearch-keystore
+    show xpack.security.transport.ssl.secure_key_passphrase
+  when:
+    - "'xpack.security.transport.ssl.secure_key_passphrase' in elasticsearch_keystore.stdout_lines"
+    - elasticsearch_cert_source == 'external'
+    - (_elasticsearch_transport_cert_format | default('')) == 'pem'
+  register: elasticsearch_transport_ssl_secure_key_passphrase
+  changed_when: false
+  no_log: true
+  ignore_errors: "{{ ansible_check_mode }}"
+
 - name: Set xpack.security.transport.ssl.secure_key_passphrase
   ansible.builtin.command: >
     /usr/share/elasticsearch/bin/elasticsearch-keystore
     add -f -x 'xpack.security.transport.ssl.secure_key_passphrase'
   args:
     stdin: "{{ elasticsearch_transport_tls_key_passphrase }}"
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - elasticsearch_cert_source == 'external'
     - (_elasticsearch_transport_cert_format | default('')) == 'pem'
     - elasticsearch_transport_tls_key_passphrase | length > 0
+    - >-
+      elasticsearch_transport_ssl_secure_key_passphrase.stdout is undefined or
+      elasticsearch_transport_tls_key_passphrase != elasticsearch_transport_ssl_secure_key_passphrase.stdout
   notify:
     - Restart Elasticsearch
+
+- name: Get xpack.security.http.ssl.secure_key_passphrase
+  ansible.builtin.command: >
+    /usr/share/elasticsearch/bin/elasticsearch-keystore
+    show xpack.security.http.ssl.secure_key_passphrase
+  when:
+    - "'xpack.security.http.ssl.secure_key_passphrase' in elasticsearch_keystore.stdout_lines"
+    - elasticsearch_cert_source == 'external'
+    - (_elasticsearch_http_cert_format | default('')) == 'pem'
+    - elasticsearch_http_security
+  register: elasticsearch_http_ssl_secure_key_passphrase
+  changed_when: false
+  no_log: true
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Set xpack.security.http.ssl.secure_key_passphrase
   ansible.builtin.command: >
@@ -249,13 +292,17 @@
     add -f -x 'xpack.security.http.ssl.secure_key_passphrase'
   args:
     stdin: "{{ elasticsearch_http_tls_key_passphrase | default(elasticsearch_transport_tls_key_passphrase, true) }}"
-  changed_when: false
+  changed_when: true
   no_log: true
   when:
     - elasticsearch_cert_source == 'external'
     - (_elasticsearch_http_cert_format | default('')) == 'pem'
     - (elasticsearch_http_tls_key_passphrase | default(elasticsearch_transport_tls_key_passphrase, true)) | length > 0
     - elasticsearch_http_security
+    - >-
+      elasticsearch_http_ssl_secure_key_passphrase.stdout is undefined or
+      (elasticsearch_http_tls_key_passphrase | default(elasticsearch_transport_tls_key_passphrase, true))
+      != elasticsearch_http_ssl_secure_key_passphrase.stdout
   notify:
     - Restart Elasticsearch
 

--- a/roles/repos/tasks/redhat.yml
+++ b/roles/repos/tasks/redhat.yml
@@ -28,11 +28,15 @@
           ansible.builtin.package:
             name: crypto-policies-scripts
 
-        # since we don't expect to have that workaround for long
-        # we can skip having idempotency checks fixed
+        - name: Check current crypto policy
+          ansible.builtin.command: update-crypto-policies --show
+          register: _crypto_policy
+          changed_when: false
+
         - name: Set Crypto policies to legacy
           ansible.builtin.command: "update-crypto-policies --set LEGACY"
-          changed_when: false
+          changed_when: true
+          when: _crypto_policy.stdout != 'LEGACY'
 
 - name: Ensure Elastic repository key is available (RedHat)
   ansible.builtin.rpm_key:


### PR DESCRIPTION
The keystore tasks in the elasticsearch role had misleading `changed_when: false` on commands that actually modify state. This meant Ansible never reported changes from keystore operations and the restart handler could miss cases where it should have fired.

The remove tasks (4 total) only run when their `when` condition confirms the entry exists, so they always change state when they execute. Switched to `changed_when: true`.

The SSL password set tasks already had value-comparison `when` conditions, so they only run when the stored value differs from the desired one. Also switched to `changed_when: true`.

The bootstrap password and PEM key passphrase tasks ran unconditionally without checking the current value. Added get-then-compare pre-checks following the same pattern the SSL password tasks already use, so they skip the write when the keystore already holds the correct value.

The RHEL crypto-policies task now checks the current policy with `update-crypto-policies --show` and skips the set if already LEGACY.

Fixes #45