### PR TITLE
Harden SSH connections for CI molecule tests

### DIFF
--- a/.github/workflows/test_elasticsearch_custom_certs.yml
+++ b/.github/workflows/test_elasticsearch_custom_certs.yml
@@ -57,6 +57,8 @@ jobs:
         -o ControlMaster=auto
         -o ControlPersist=300s
         -o PreferredAuthentications=publickey
+        -o ServerAliveInterval=30
+        -o ServerAliveCountMax=3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test_elasticsearch_modules.yml
+++ b/.github/workflows/test_elasticsearch_modules.yml
@@ -51,6 +51,8 @@ jobs:
         -o ControlMaster=auto
         -o ControlPersist=300s
         -o PreferredAuthentications=publickey
+        -o ServerAliveInterval=30
+        -o ServerAliveCountMax=3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test_elasticsearch_upgrade.yml
+++ b/.github/workflows/test_elasticsearch_upgrade.yml
@@ -57,6 +57,8 @@ jobs:
         -o ControlMaster=auto
         -o ControlPersist=300s
         -o PreferredAuthentications=publickey
+        -o ServerAliveInterval=30
+        -o ServerAliveCountMax=3
 
     strategy:
       fail-fast: false
@@ -148,6 +150,8 @@ jobs:
         -o ControlMaster=auto
         -o ControlPersist=300s
         -o PreferredAuthentications=publickey
+        -o ServerAliveInterval=30
+        -o ServerAliveCountMax=3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -58,6 +58,8 @@ jobs:
         -o ControlMaster=auto
         -o ControlPersist=300s
         -o PreferredAuthentications=publickey
+        -o ServerAliveInterval=30
+        -o ServerAliveCountMax=3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test_role_beats.yml
+++ b/.github/workflows/test_role_beats.yml
@@ -56,6 +56,8 @@ jobs:
         -o ControlMaster=auto
         -o ControlPersist=300s
         -o PreferredAuthentications=publickey
+        -o ServerAliveInterval=30
+        -o ServerAliveCountMax=3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test_role_elasticsearch.yml
+++ b/.github/workflows/test_role_elasticsearch.yml
@@ -56,6 +56,8 @@ jobs:
         -o ControlMaster=auto
         -o ControlPersist=300s
         -o PreferredAuthentications=publickey
+        -o ServerAliveInterval=30
+        -o ServerAliveCountMax=3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -56,6 +56,8 @@ jobs:
         -o ControlMaster=auto
         -o ControlPersist=300s
         -o PreferredAuthentications=publickey
+        -o ServerAliveInterval=30
+        -o ServerAliveCountMax=3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -56,6 +56,8 @@ jobs:
         -o ControlMaster=auto
         -o ControlPersist=300s
         -o PreferredAuthentications=publickey
+        -o ServerAliveInterval=30
+        -o ServerAliveCountMax=3
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -56,6 +56,8 @@ jobs:
         -o ControlMaster=auto
         -o ControlPersist=300s
         -o PreferredAuthentications=publickey
+        -o ServerAliveInterval=30
+        -o ServerAliveCountMax=3
 
     strategy:
       fail-fast: false

--- a/molecule/beats_advanced/molecule.yml
+++ b/molecule/beats_advanced/molecule.yml
@@ -17,10 +17,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/beats_default/molecule.yml
+++ b/molecule/beats_default/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/beats_peculiar/molecule.yml
+++ b/molecule/beats_peculiar/molecule.yml
@@ -17,10 +17,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/beats_security/molecule.yml
+++ b/molecule/beats_security/molecule.yml
@@ -24,10 +24,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/cert_renewal/molecule.yml
+++ b/molecule/cert_renewal/molecule.yml
@@ -26,10 +26,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/elasticsearch_cert_content/molecule.yml
+++ b/molecule/elasticsearch_cert_content/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/elasticsearch_custom/molecule.yml
+++ b/molecule/elasticsearch_custom/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/elasticsearch_custom_certs/molecule.yml
+++ b/molecule/elasticsearch_custom_certs/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/elasticsearch_custom_certs_minimal/molecule.yml
+++ b/molecule/elasticsearch_custom_certs_minimal/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/elasticsearch_default/molecule.yml
+++ b/molecule/elasticsearch_default/molecule.yml
@@ -24,10 +24,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/elasticsearch_no-security/molecule.yml
+++ b/molecule/elasticsearch_no-security/molecule.yml
@@ -24,10 +24,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/elasticsearch_roles_calculation/molecule.yml
+++ b/molecule/elasticsearch_roles_calculation/molecule.yml
@@ -29,10 +29,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/elasticsearch_test_modules/molecule.yml
+++ b/molecule/elasticsearch_test_modules/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/elasticsearch_upgrade_8to9/molecule.yml
+++ b/molecule/elasticsearch_upgrade_8to9/molecule.yml
@@ -26,10 +26,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/elasticsearch_upgrade_8to9_single/molecule.yml
+++ b/molecule/elasticsearch_upgrade_8to9_single/molecule.yml
@@ -21,10 +21,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/elasticstack_default/molecule.yml
+++ b/molecule/elasticstack_default/molecule.yml
@@ -29,10 +29,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/es_kibana/molecule.yml
+++ b/molecule/es_kibana/molecule.yml
@@ -29,10 +29,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/kibana_custom/molecule.yml
+++ b/molecule/kibana_custom/molecule.yml
@@ -24,10 +24,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/kibana_custom_certs/molecule.yml
+++ b/molecule/kibana_custom_certs/molecule.yml
@@ -24,10 +24,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/kibana_default/molecule.yml
+++ b/molecule/kibana_default/molecule.yml
@@ -16,10 +16,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/logstash_advanced/molecule.yml
+++ b/molecule/logstash_advanced/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/logstash_centralized_pipelines/molecule.yml
+++ b/molecule/logstash_centralized_pipelines/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/logstash_custom_pipeline/molecule.yml
+++ b/molecule/logstash_custom_pipeline/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/logstash_default/molecule.yml
+++ b/molecule/logstash_default/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/logstash_elasticsearch/molecule.yml
+++ b/molecule/logstash_elasticsearch/molecule.yml
@@ -24,10 +24,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/logstash_ssl/molecule.yml
+++ b/molecule/logstash_ssl/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/logstash_standalone_certs/molecule.yml
+++ b/molecule/logstash_standalone_certs/molecule.yml
@@ -19,10 +19,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/repos_default/molecule.yml
+++ b/molecule/repos_default/molecule.yml
@@ -17,10 +17,9 @@ provisioner:
   connection_options:
     ansible_connection: ssh
     ansible_user: root
-    ansible_ssh_retries: 3
     ansible_ssh_common_args: >-
       -o StrictHostKeyChecking=no
-      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes
+      -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10
       -i ${MOLECULE_SSH_KEY:-~/.ssh/molecule_id_ed25519}
       -W %h:%p root@${INCUS_HOST:-172.30.0.172}"
   inventory:

--- a/molecule/shared/create.yml
+++ b/molecule/shared/create.yml
@@ -154,7 +154,7 @@
       ansible.builtin.command:
         cmd: >-
           ssh -o StrictHostKeyChecking=no -o ConnectTimeout=5 -o BatchMode=yes
-          -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -i {{ molecule_ssh_key }} -W %h:%p root@{{ incus_host }}"
+          -o "ProxyCommand=ssh -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=10 -i {{ molecule_ssh_key }} -W %h:%p root@{{ incus_host }}"
           -i {{ molecule_ssh_key }}
           root@{{ _instance_addresses[item.name] }} true
       loop: "{{ molecule_yml.platforms }}"


### PR DESCRIPTION
The ProxyCommand SSH to the Incus host had no ConnectTimeout, so a hanging connection would block indefinitely. There was also no keepalive detection on the Ansible side, so a dead ControlMaster socket went unnoticed until the next task tried to use it and got "kex_exchange_identification: Connection closed by remote host" or "Connection timed out during banner exchange". The per-host ansible_ssh_retries of 3 in molecule.yml was overriding the workflow default of 5, reducing tolerance for transient failures.

Changes in this PR:
- ConnectTimeout=10 added to ProxyCommand in all 28 molecule.yml files and create.yml
- ServerAliveInterval=30 and ServerAliveCountMax=3 added to ANSIBLE_SSH_ARGS in all 9 workflow files
- ansible_ssh_retries removed from molecule.yml so the workflow default of 5 takes effect
- Incus host sshd MaxSessions raised from default 10 to 200 (applied live, not in this PR)


🤖 Generated with [Claude Code](https://claude.com/claude-code)