### PR TITLE
Isolate SSH state per CI job to prevent cross-job interference

### DIFF
--- a/.github/workflows/test_elasticsearch_custom_certs.yml
+++ b/.github/workflows/test_elasticsearch_custom_certs.yml
@@ -85,6 +85,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection and dependencies
         run: |
@@ -150,6 +152,11 @@ jobs:
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
 
-      - name: Clean up SSH key
+      - name: Clean up SSH state
         if: always()
-        run: rm -f ${{ runner.temp }}/molecule_id_ed25519
+        run: |
+          # Kill orphaned ProxyCommand SSH processes from this job
+          pkill -f "${{ runner.temp }}/molecule_id_ed25519" 2>/dev/null || true
+          # Remove ControlMaster sockets and SSH key
+          rm -rf "${{ runner.temp }}/ssh-cp"
+          rm -f "${{ runner.temp }}/molecule_id_ed25519"

--- a/.github/workflows/test_elasticsearch_modules.yml
+++ b/.github/workflows/test_elasticsearch_modules.yml
@@ -78,6 +78,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection and dependencies
         run: |
@@ -143,6 +145,11 @@ jobs:
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
 
-      - name: Clean up SSH key
+      - name: Clean up SSH state
         if: always()
-        run: rm -f ${{ runner.temp }}/molecule_id_ed25519
+        run: |
+          # Kill orphaned ProxyCommand SSH processes from this job
+          pkill -f "${{ runner.temp }}/molecule_id_ed25519" 2>/dev/null || true
+          # Remove ControlMaster sockets and SSH key
+          rm -rf "${{ runner.temp }}/ssh-cp"
+          rm -f "${{ runner.temp }}/molecule_id_ed25519"

--- a/.github/workflows/test_elasticsearch_upgrade.yml
+++ b/.github/workflows/test_elasticsearch_upgrade.yml
@@ -82,6 +82,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -128,9 +130,14 @@ jobs:
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
 
-      - name: Clean up SSH key
+      - name: Clean up SSH state
         if: always()
-        run: rm -f ${{ runner.temp }}/molecule_id_ed25519
+        run: |
+          # Kill orphaned ProxyCommand SSH processes from this job
+          pkill -f "${{ runner.temp }}/molecule_id_ed25519" 2>/dev/null || true
+          # Remove ControlMaster sockets and SSH key
+          rm -rf "${{ runner.temp }}/ssh-cp"
+          rm -f "${{ runner.temp }}/molecule_id_ed25519"
 
   upgrade_single_node:
     needs: lint_elasticsearch
@@ -175,6 +182,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -221,6 +230,11 @@ jobs:
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
 
-      - name: Clean up SSH key
+      - name: Clean up SSH state
         if: always()
-        run: rm -f ${{ runner.temp }}/molecule_id_ed25519
+        run: |
+          # Kill orphaned ProxyCommand SSH processes from this job
+          pkill -f "${{ runner.temp }}/molecule_id_ed25519" 2>/dev/null || true
+          # Remove ControlMaster sockets and SSH key
+          rm -rf "${{ runner.temp }}/ssh-cp"
+          rm -f "${{ runner.temp }}/molecule_id_ed25519"

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -89,6 +89,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -137,9 +139,14 @@ jobs:
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
 
-      - name: Clean up SSH key
+      - name: Clean up SSH state
         if: always()
-        run: rm -f ${{ runner.temp }}/molecule_id_ed25519
+        run: |
+          # Kill orphaned ProxyCommand SSH processes from this job
+          pkill -f "${{ runner.temp }}/molecule_id_ed25519" 2>/dev/null || true
+          # Remove ControlMaster sockets and SSH key
+          rm -rf "${{ runner.temp }}/ssh-cp"
+          rm -f "${{ runner.temp }}/molecule_id_ed25519"
 
   full_stack_gate:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_plugins.yml
+++ b/.github/workflows/test_plugins.yml
@@ -75,6 +75,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -115,6 +117,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -157,6 +161,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -197,6 +203,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -239,6 +247,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |

--- a/.github/workflows/test_role_beats.yml
+++ b/.github/workflows/test_role_beats.yml
@@ -80,6 +80,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -128,6 +130,11 @@ jobs:
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
 
-      - name: Clean up SSH key
+      - name: Clean up SSH state
         if: always()
-        run: rm -f ${{ runner.temp }}/molecule_id_ed25519
+        run: |
+          # Kill orphaned ProxyCommand SSH processes from this job
+          pkill -f "${{ runner.temp }}/molecule_id_ed25519" 2>/dev/null || true
+          # Remove ControlMaster sockets and SSH key
+          rm -rf "${{ runner.temp }}/ssh-cp"
+          rm -f "${{ runner.temp }}/molecule_id_ed25519"

--- a/.github/workflows/test_role_elasticsearch.yml
+++ b/.github/workflows/test_role_elasticsearch.yml
@@ -85,6 +85,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -133,6 +135,11 @@ jobs:
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
 
-      - name: Clean up SSH key
+      - name: Clean up SSH state
         if: always()
-        run: rm -f ${{ runner.temp }}/molecule_id_ed25519
+        run: |
+          # Kill orphaned ProxyCommand SSH processes from this job
+          pkill -f "${{ runner.temp }}/molecule_id_ed25519" 2>/dev/null || true
+          # Remove ControlMaster sockets and SSH key
+          rm -rf "${{ runner.temp }}/ssh-cp"
+          rm -f "${{ runner.temp }}/molecule_id_ed25519"

--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -80,6 +80,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -128,6 +130,11 @@ jobs:
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
 
-      - name: Clean up SSH key
+      - name: Clean up SSH state
         if: always()
-        run: rm -f ${{ runner.temp }}/molecule_id_ed25519
+        run: |
+          # Kill orphaned ProxyCommand SSH processes from this job
+          pkill -f "${{ runner.temp }}/molecule_id_ed25519" 2>/dev/null || true
+          # Remove ControlMaster sockets and SSH key
+          rm -rf "${{ runner.temp }}/ssh-cp"
+          rm -f "${{ runner.temp }}/molecule_id_ed25519"

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -87,6 +87,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -135,6 +137,11 @@ jobs:
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
 
-      - name: Clean up SSH key
+      - name: Clean up SSH state
         if: always()
-        run: rm -f ${{ runner.temp }}/molecule_id_ed25519
+        run: |
+          # Kill orphaned ProxyCommand SSH processes from this job
+          pkill -f "${{ runner.temp }}/molecule_id_ed25519" 2>/dev/null || true
+          # Remove ControlMaster sockets and SSH key
+          rm -rf "${{ runner.temp }}/ssh-cp"
+          rm -f "${{ runner.temp }}/molecule_id_ed25519"

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -85,6 +85,8 @@ jobs:
         run: |
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
+          echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
         run: |
@@ -132,6 +134,11 @@ jobs:
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
 
-      - name: Clean up SSH key
+      - name: Clean up SSH state
         if: always()
-        run: rm -f ${{ runner.temp }}/molecule_id_ed25519
+        run: |
+          # Kill orphaned ProxyCommand SSH processes from this job
+          pkill -f "${{ runner.temp }}/molecule_id_ed25519" 2>/dev/null || true
+          # Remove ControlMaster sockets and SSH key
+          rm -rf "${{ runner.temp }}/ssh-cp"
+          rm -f "${{ runner.temp }}/molecule_id_ed25519"


### PR DESCRIPTION
Each GitHub Actions runner shares `~/.ansible/cp/` for ControlMaster sockets across all jobs. When a job is cancelled mid-converge, stale sockets and orphaned ProxyCommand processes linger and can interfere with subsequent jobs on the same runner. This was causing UNREACHABLE errors when many PRs triggered CI simultaneously (the thundering herd from force-pushing 8 branches at once).

Each job now gets its own `ANSIBLE_SSH_CONTROL_PATH_DIR` under `$RUNNER_TEMP/ssh-cp`, providing complete isolation between concurrent jobs. The cleanup step (`if: always()`) kills orphaned SSH processes matched by the job-unique SSH key path, removes the socket directory, and deletes the key.

This builds on PR #62 (ConnectTimeout, ServerAliveInterval, ssh_retries) to make the CI SSH layer fully robust.


🤖 Generated with [Claude Code](https://claude.com/claude-code)