### PR TITLE
Fix container name collisions across concurrent CI runs

### DIFF
--- a/.github/workflows/test_elasticsearch_custom_certs.yml
+++ b/.github/workflows/test_elasticsearch_custom_certs.yml
@@ -86,6 +86,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection and dependencies

--- a/.github/workflows/test_elasticsearch_modules.yml
+++ b/.github/workflows/test_elasticsearch_modules.yml
@@ -79,6 +79,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection and dependencies

--- a/.github/workflows/test_elasticsearch_upgrade.yml
+++ b/.github/workflows/test_elasticsearch_upgrade.yml
@@ -83,6 +83,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
@@ -183,6 +184,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -90,6 +90,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection

--- a/.github/workflows/test_plugins.yml
+++ b/.github/workflows/test_plugins.yml
@@ -76,6 +76,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
@@ -118,6 +119,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
@@ -162,6 +164,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
@@ -204,6 +207,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection
@@ -248,6 +252,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection

--- a/.github/workflows/test_role_beats.yml
+++ b/.github/workflows/test_role_beats.yml
@@ -81,6 +81,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection

--- a/.github/workflows/test_role_elasticsearch.yml
+++ b/.github/workflows/test_role_elasticsearch.yml
@@ -86,6 +86,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection

--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -81,6 +81,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -88,6 +88,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -86,6 +86,7 @@ jobs:
           echo "ANSIBLE_COLLECTIONS_PATH=$RUNNER_TEMP/collections" >> "$GITHUB_ENV"
           echo "MOLECULE_EPHEMERAL_DIRECTORY=$RUNNER_TEMP/molecule" >> "$GITHUB_ENV"
           echo "ANSIBLE_SSH_CONTROL_PATH_DIR=$RUNNER_TEMP/ssh-cp" >> "$GITHUB_ENV"
+          echo "MOLECULE_RUN_SUFFIX=-${GITHUB_RUN_ID: -6}" >> "$GITHUB_ENV"
           mkdir -p "$RUNNER_TEMP/ssh-cp"
 
       - name: Install collection

--- a/molecule/beats_advanced/molecule.yml
+++ b/molecule/beats_advanced/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "beats-adv-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "beats-adv-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     distro: "${MOLECULE_DISTRO:-debian12}"
     memory_mb: 1024
 provisioner:

--- a/molecule/beats_default/molecule.yml
+++ b/molecule/beats_default/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: beats-def-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}
+  - name: beats-def-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"

--- a/molecule/beats_peculiar/molecule.yml
+++ b/molecule/beats_peculiar/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: beats-pec-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}
+  - name: beats-pec-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}
     distro: "${MOLECULE_DISTRO:-debian11}"
     memory_mb: 1024
 provisioner:

--- a/molecule/beats_security/molecule.yml
+++ b/molecule/beats_security/molecule.yml
@@ -7,12 +7,12 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "beats-sec-es1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "beats-sec-es1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"
     memory_mb: 3328
-  - name: "beats-sec-fb1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "beats-sec-fb1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - beats
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/cert_renewal/molecule.yml
+++ b/molecule/cert_renewal/molecule.yml
@@ -7,13 +7,13 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "cert-renew-es1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "cert-renew-es1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
       - logstash
     distro: "${MOLECULE_DISTRO:-debian12}"
     memory_mb: 4096
-  - name: "cert-renew-es2-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "cert-renew-es2-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
       - kibana

--- a/molecule/elasticsearch_cert_content/molecule.yml
+++ b/molecule/elasticsearch_cert_content/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "es-crtcnt-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "es-crtcnt-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/elasticsearch_custom/molecule.yml
+++ b/molecule/elasticsearch_custom/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "es-custom-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "es-custom-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"

--- a/molecule/elasticsearch_custom_certs/molecule.yml
+++ b/molecule/elasticsearch_custom_certs/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "es-extcrt-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "es-extcrt-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/elasticsearch_custom_certs_minimal/molecule.yml
+++ b/molecule/elasticsearch_custom_certs_minimal/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "es-mincrt-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "es-mincrt-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/elasticsearch_default/molecule.yml
+++ b/molecule/elasticsearch_default/molecule.yml
@@ -7,12 +7,12 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "es-def1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "es-def1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"
     memory_mb: 3328
-  - name: "es-def2-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "es-def2-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"

--- a/molecule/elasticsearch_no-security/molecule.yml
+++ b/molecule/elasticsearch_no-security/molecule.yml
@@ -7,12 +7,12 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "elasticsearch-nosecurity1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "elasticsearch-nosecurity1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearchXYZ
     distro: "${MOLECULE_DISTRO:-debian11}"
     memory_mb: 3328
-  - name: "elasticsearch-nosecurity2-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "elasticsearch-nosecurity2-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearchXYZ
     distro: "${MOLECULE_DISTRO:-debian11}"

--- a/molecule/elasticsearch_roles_calculation/molecule.yml
+++ b/molecule/elasticsearch_roles_calculation/molecule.yml
@@ -7,17 +7,17 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "es-calc1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "es-calc1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"
     memory_mb: 3328
-  - name: "es-calc2-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "es-calc2-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"
     memory_mb: 3328
-  - name: "es-calc3-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "es-calc3-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"

--- a/molecule/elasticsearch_test_modules/molecule.yml
+++ b/molecule/elasticsearch_test_modules/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "es-mod-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "es-mod-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"

--- a/molecule/elasticsearch_upgrade_8to9/molecule.yml
+++ b/molecule/elasticsearch_upgrade_8to9/molecule.yml
@@ -9,12 +9,12 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "es-upg89-n1-${MOLECULE_DISTRO:-debian11}"
+  - name: "es-upg89-n1-${MOLECULE_DISTRO:-debian11}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"
     memory_mb: 3328
-  - name: "es-upg89-n2-${MOLECULE_DISTRO:-debian11}"
+  - name: "es-upg89-n2-${MOLECULE_DISTRO:-debian11}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"

--- a/molecule/elasticsearch_upgrade_8to9_single/molecule.yml
+++ b/molecule/elasticsearch_upgrade_8to9_single/molecule.yml
@@ -9,7 +9,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "es-upgs-${MOLECULE_DISTRO:-debian11}"
+  - name: "es-upgs-${MOLECULE_DISTRO:-debian11}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"

--- a/molecule/elasticstack_default/molecule.yml
+++ b/molecule/elasticstack_default/molecule.yml
@@ -7,14 +7,14 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "elasticstack${ELASTIC_RELEASE:-9}-cluster1-${MOLECULE_DISTRO:-debian12}"
+  - name: "elasticstack${ELASTIC_RELEASE:-9}-cluster1-${MOLECULE_DISTRO:-debian12}${MOLECULE_RUN_SUFFIX}"
     groups:
       - beats
       - logstash
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"
     memory_mb: 7680
-  - name: "elasticstack${ELASTIC_RELEASE:-9}-cluster2-${MOLECULE_DISTRO:-debian12}"
+  - name: "elasticstack${ELASTIC_RELEASE:-9}-cluster2-${MOLECULE_DISTRO:-debian12}${MOLECULE_RUN_SUFFIX}"
     groups:
       - beats
       - kibana
@@ -39,7 +39,7 @@ provisioner:
       all:
         ansible_python_interpreter: /usr/bin/python3
     host_vars:
-      elasticstack${ELASTIC_RELEASE:-9}-cluster2-${MOLECULE_DISTRO:-debian12}:
+      elasticstack${ELASTIC_RELEASE:-9}-cluster2-${MOLECULE_DISTRO:-debian12}${MOLECULE_RUN_SUFFIX}:
         elasticsearch_tls_key_passphrase: UniqueHostPassword
 
   # Just enable temporarily. Sometimes it's useful, but most of the time it's

--- a/molecule/es_kibana/molecule.yml
+++ b/molecule/es_kibana/molecule.yml
@@ -7,17 +7,17 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "eskb-es1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "eskb-es1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"
     memory_mb: 3328
-  - name: "eskb-es2-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "eskb-es2-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"
     memory_mb: 3328
-  - name: "eskb-kb1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "eskb-kb1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - kibana
     distro: "${MOLECULE_DISTRO:-debian11}"

--- a/molecule/kibana_custom/molecule.yml
+++ b/molecule/kibana_custom/molecule.yml
@@ -7,12 +7,12 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "kib-cust-es1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "kib-cust-es1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"
     memory_mb: 3328
-  - name: "kib-cust-kb1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "kib-cust-kb1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - kibana
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/kibana_custom_certs/molecule.yml
+++ b/molecule/kibana_custom_certs/molecule.yml
@@ -7,12 +7,12 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "kib-extcrt-es1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "kib-extcrt-es1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"
     memory_mb: 3328
-  - name: "kib-extcrt-kb1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "kib-extcrt-kb1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - kibana
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/kibana_default/molecule.yml
+++ b/molecule/kibana_default/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "kib-def-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "kib-def-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     distro: "${MOLECULE_DISTRO:-debian11}"
 provisioner:
   name: ansible

--- a/molecule/logstash_advanced/molecule.yml
+++ b/molecule/logstash_advanced/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "ls-adv-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "ls-adv-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - logstash
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/logstash_centralized_pipelines/molecule.yml
+++ b/molecule/logstash_centralized_pipelines/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "ls-cpm-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "ls-cpm-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - logstash
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/logstash_custom_pipeline/molecule.yml
+++ b/molecule/logstash_custom_pipeline/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "ls-cpipe-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "ls-cpipe-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - logstash
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/logstash_default/molecule.yml
+++ b/molecule/logstash_default/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "ls-def-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "ls-def-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - logstash
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/logstash_elasticsearch/molecule.yml
+++ b/molecule/logstash_elasticsearch/molecule.yml
@@ -7,12 +7,12 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "ls-es-es1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "ls-es-es1-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian11}"
     memory_mb: 3328
-  - name: "ls-es-ls1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "ls-es-ls1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - logstash
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/logstash_ssl/molecule.yml
+++ b/molecule/logstash_ssl/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "ls-ssl-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "ls-ssl-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - logstash
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/logstash_standalone_certs/molecule.yml
+++ b/molecule/logstash_standalone_certs/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "ls-certs-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}"
+  - name: "ls-certs-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - logstash
     distro: "${MOLECULE_DISTRO:-debian12}"

--- a/molecule/repos_default/molecule.yml
+++ b/molecule/repos_default/molecule.yml
@@ -7,7 +7,7 @@ dependency:
 driver:
   name: default
 platforms:
-  - name: "repos-def-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}"
+  - name: "repos-def-${MOLECULE_DISTRO:-debian11}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     distro: "${MOLECULE_DISTRO:-debian11}"
     memory_mb: 512
 provisioner:


### PR DESCRIPTION
When multiple PRs trigger the same workflow simultaneously, their molecule jobs create containers with identical names (e.g. `cert-renew-es1-rockylinux9-r9`). The `create.yml` playbook starts by force-deleting any container with the target name before launching a new one, so when PR B's job starts, it kills PR A's running container and creates a new one at a different IP. PR A's SSH ControlMaster connection then dies with `kex_exchange_identification: Connection closed by remote host`.

This was confirmed by correlating the Incus host sshd logs (`error: connect_to 10.99.0.X port 22: failed`) with the IPs of containers that had been destroyed and recreated by concurrent jobs.

The fix appends a per-run suffix (last 6 digits of `GITHUB_RUN_ID`) to every container name via `MOLECULE_RUN_SUFFIX`. For local development the variable is unset, so names stay clean. Container names like `cert-renew-es1-rockylinux9-r9-103155` are unique per workflow run, preventing any cross-job interference.

Changes across 28 molecule.yml files (container names + one host_vars key) and 10 workflow files (setting the env var).