### PR TITLE
Fix agentry CI workflows and add feature-implement

### DIFF
--- a/.github/workflows/agentry-bug-fix.yaml
+++ b/.github/workflows/agentry-bug-fix.yaml
@@ -3,20 +3,23 @@ on:
   issues:
     types: [labeled]
 permissions:
-  contents: write
+  contents: write # needed for pr:create to push branches
   pull-requests: write
   issues: write
+concurrency:
+  group: agentry-bug-fix-${{ github.event.issue.number }}
+  cancel-in-progress: true
 jobs:
   agentry:
     runs-on: ubuntu-latest
     if: github.event.label.name == 'bug'
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.12'
     - name: Install Claude Code

--- a/.github/workflows/agentry-bug-fix.yaml
+++ b/.github/workflows/agentry-bug-fix.yaml
@@ -1,4 +1,4 @@
-name: 'Agentry: bug-fix'
+name: 'Agentry: Bug Fix'
 on:
   issues:
     types: [labeled]
@@ -24,7 +24,10 @@ jobs:
     - name: Install agentry
       run: pip install "agentry @ git+https://github.com/norrietaylor/agentry.git"
     - name: Diagnose and fix bug
-      run: agentry run workflows/bug-fix.yaml --binder github-actions
+      run: >
+        agentry --output-format json run workflows/bug-fix.yaml
+        --input repository-ref=.
+        --binder github-actions
       env:
         CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/agentry-code-review.yaml
+++ b/.github/workflows/agentry-code-review.yaml
@@ -5,17 +5,20 @@ on:
 permissions:
   contents: read
   pull-requests: write
+concurrency:
+  group: agentry-code-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 jobs:
   agentry:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.12'
     - name: Install Claude Code

--- a/.github/workflows/agentry-feature-implement.yaml
+++ b/.github/workflows/agentry-feature-implement.yaml
@@ -1,14 +1,15 @@
-name: 'Agentry: Code Review'
+name: 'Agentry: Feature Implement'
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  issues:
+    types: [labeled]
 permissions:
-  contents: read
+  contents: write
+  issues: write
   pull-requests: write
 jobs:
   agentry:
+    if: github.event.label.name == 'feature'
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -22,11 +23,10 @@ jobs:
       run: npm install -g @anthropic-ai/claude-code
     - name: Install agentry
       run: pip install "agentry @ git+https://github.com/norrietaylor/agentry.git"
-    - name: Run code review
+    - name: Implement feature
       run: >
-        agentry --output-format json run workflows/code-review.yaml
-        --input diff=${{ github.event.pull_request.head.sha }}~1
-        --input codebase=.
+        agentry --output-format json run workflows/feature-implement.yaml
+        --input repository-ref=.
         --binder github-actions
       env:
         CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/agentry-feature-implement.yaml
+++ b/.github/workflows/agentry-feature-implement.yaml
@@ -3,20 +3,23 @@ on:
   issues:
     types: [labeled]
 permissions:
-  contents: write
+  contents: write # needed for pr:create to push branches
   issues: write
   pull-requests: write
+concurrency:
+  group: agentry-feature-implement-${{ github.event.issue.number }}
+  cancel-in-progress: true
 jobs:
   agentry:
     if: github.event.label.name == 'feature'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.12'
     - name: Install Claude Code

--- a/.github/workflows/agentry-triage.yaml
+++ b/.github/workflows/agentry-triage.yaml
@@ -5,14 +5,17 @@ on:
 permissions:
   contents: read
   issues: write
+concurrency:
+  group: agentry-triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
 jobs:
   agentry:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.12'
     - name: Install Claude Code

--- a/.github/workflows/agentry-triage.yaml
+++ b/.github/workflows/agentry-triage.yaml
@@ -1,4 +1,4 @@
-name: 'Agentry: triage'
+name: 'Agentry: Planning Pipeline'
 on:
   issues:
     types: [opened, reopened]
@@ -19,8 +19,11 @@ jobs:
       run: npm install -g @anthropic-ai/claude-code
     - name: Install agentry
       run: pip install "agentry @ git+https://github.com/norrietaylor/agentry.git"
-    - name: Triage issue
-      run: agentry run workflows/triage.yaml --binder github-actions
+    - name: Run planning pipeline
+      run: >
+        agentry --output-format json run workflows/planning-pipeline.yaml
+        --input repository-ref=.
+        --binder github-actions
       env:
         CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflows/feature-implement.yaml
+++ b/workflows/feature-implement.yaml
@@ -1,0 +1,61 @@
+identity:
+  name: feature-implement
+  version: 1.0.0
+  description: Implement a feature or decompose it into sub-issues if too large.
+
+inputs:
+  issue-description:
+    type: string
+    required: true
+    description: The feature request to implement.
+    source: issue.body
+    fallback: issue.title
+  repository-ref:
+    type: repository-ref
+    required: true
+    description: The repository in which to implement the feature.
+
+tools:
+  capabilities:
+    - repository:read
+    - shell:execute
+    - pr:create
+    - issue:comment
+    - issue:label
+    - issue:create
+
+agent:
+  runtime: claude-code
+  model: claude-sonnet-4-20250514
+  system_prompt: prompts/feature-implement.md
+  max_iterations: 10
+
+safety:
+  trust: elevated
+  resources:
+    timeout: 600
+
+output:
+  schema:
+    type: object
+    required: [action, reasoning]
+    properties:
+      action:
+        type: string
+        enum: [implemented, decomposed]
+      pr_url:
+        type: string
+      sub_issues:
+        type: array
+        items:
+          type: string
+      reasoning:
+        type: string
+  side_effects:
+    - type: terminal
+      description: Print implementation or decomposition summary to stdout
+  output_paths:
+    - feature-implement-result.json
+
+composition:
+  steps: []

--- a/workflows/prompts/feature-implement.md
+++ b/workflows/prompts/feature-implement.md
@@ -1,0 +1,46 @@
+# Feature Implement Agent — Elasticstack Ansible Collection
+
+You are an expert Ansible developer implementing features for a collection that
+deploys the Elastic Stack (Elasticsearch, Kibana, Logstash, Beats).
+
+## Decision: Implement or Decompose
+
+**Implement directly** if the change touches 5 or fewer files and requires 500 or
+fewer lines of new or modified code.
+
+**Decompose** if the change spans more than 5 files, more than 500 lines, or
+requires coordinated changes across multiple roles that would be risky in one PR.
+
+When in doubt, prefer decomposition to keep PRs reviewable.
+
+## If Implementing
+
+1. Read the relevant role files to understand existing patterns and conventions.
+2. Implement the feature with appropriate molecule test coverage.
+3. Follow the fix workflow from CLAUDE.md: prefer extending existing molecule
+   scenarios over creating new ones (each adds ~10 min CI).
+4. Commit with a message referencing the issue number.
+5. Open a PR with label `agent-proposed`.
+6. Comment on the original issue linking to the PR.
+
+## If Decomposing
+
+1. Break the feature into sub-tasks, each implementable in a single PR.
+2. Respect role boundaries — separate tasks per role when possible.
+3. Create a GitHub issue for each sub-task with label `agent-decomposed`.
+4. Apply `agent-decomposed` label to the parent issue.
+5. Comment on the parent issue listing the sub-issues.
+
+## Project Conventions
+
+- Roles: elasticsearch, kibana, logstash, beats, repos
+- Templates in `roles/*/templates/`, defaults in `roles/*/defaults/main.yml`
+- Molecule scenarios in `molecule/` — prefer extending existing verify.yml
+- CI runs scenarios across Debian 11/12, Ubuntu 22.04/24.04, Rocky 9
+- Rolling upgrade plays must use `serial: 1`
+- New variables need defaults in `defaults/main.yml`
+
+## Output
+
+JSON object with `action` ("implemented" or "decomposed"), `reasoning`, and
+either `pr_url` or `sub_issues` array.


### PR DESCRIPTION
Fixes the agentry workflows that were failing because the generated CI templates
were used as-is without the manual tuning that agentry expects. All workflows now
pass --output-format json, --input, and --binder github-actions flags.

Also adds the feature-implement workflow (triggered by `feature` label) and
replaces the standalone triage with the full planning pipeline on issue open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated feature-implementation pipeline triggered by issue labels, including decision rules and outputs that create PRs or decomposed sub-issues.

* **Chores**
  * Updated CI workflows: renamed pipelines for clarity, added per-issue concurrency to cancel duplicate runs, pinned action versions, and switched runner invocations to emit JSON and accept explicit inputs for greater reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->