### PR TITLE
ci(agentry): prime claude-code onboarding to fix headless auth

### DIFF
--- a/.github/workflows/agentry-bug-fix.yaml
+++ b/.github/workflows/agentry-bug-fix.yaml
@@ -24,6 +24,12 @@ jobs:
         python-version: '3.12'
     - name: Install Claude Code
       run: npm install -g @anthropic-ai/claude-code
+    - name: Prime Claude Code onboarding
+      # Without this, claude -p tries to render the theme picker TUI and
+      # aborts with "Raw mode is not supported" — see anthropics/claude-code#8938.
+      run: |
+        mkdir -p ~/.claude
+        echo '{"hasCompletedOnboarding": true}' > ~/.claude.json
     - name: Install agentry
       run: pip install "agentry @ git+https://github.com/norrietaylor/agentry.git"
     - name: Diagnose and fix bug

--- a/.github/workflows/agentry-code-review.yaml
+++ b/.github/workflows/agentry-code-review.yaml
@@ -23,6 +23,12 @@ jobs:
         python-version: '3.12'
     - name: Install Claude Code
       run: npm install -g @anthropic-ai/claude-code
+    - name: Prime Claude Code onboarding
+      # Without this, claude -p tries to render the theme picker TUI and
+      # aborts with "Raw mode is not supported" — see anthropics/claude-code#8938.
+      run: |
+        mkdir -p ~/.claude
+        echo '{"hasCompletedOnboarding": true}' > ~/.claude.json
     - name: Install agentry
       run: pip install "agentry @ git+https://github.com/norrietaylor/agentry.git"
     - name: Run code review

--- a/.github/workflows/agentry-code-review.yaml
+++ b/.github/workflows/agentry-code-review.yaml
@@ -29,15 +29,6 @@ jobs:
       run: |
         mkdir -p ~/.claude
         echo '{"hasCompletedOnboarding": true}' > ~/.claude.json
-    - name: Diagnose claude auth
-      env:
-        CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-      run: |
-        set -x
-        claude --version
-        ls -la ~/.claude ~/.claude.json 2>&1 || true
-        echo 'say ok in one word' | claude -p --model claude-sonnet-4-20250514 --output-format json 2>&1 || rc=$?
-        echo "claude exit: ${rc:-0}"
     - name: Install agentry
       run: pip install "agentry @ git+https://github.com/norrietaylor/agentry.git"
     - name: Run code review

--- a/.github/workflows/agentry-code-review.yaml
+++ b/.github/workflows/agentry-code-review.yaml
@@ -29,6 +29,15 @@ jobs:
       run: |
         mkdir -p ~/.claude
         echo '{"hasCompletedOnboarding": true}' > ~/.claude.json
+    - name: Diagnose claude auth
+      env:
+        CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      run: |
+        set -x
+        claude --version
+        ls -la ~/.claude ~/.claude.json 2>&1 || true
+        echo 'say ok in one word' | claude -p --model claude-sonnet-4-20250514 --output-format json 2>&1 || rc=$?
+        echo "claude exit: ${rc:-0}"
     - name: Install agentry
       run: pip install "agentry @ git+https://github.com/norrietaylor/agentry.git"
     - name: Run code review

--- a/.github/workflows/agentry-feature-implement.yaml
+++ b/.github/workflows/agentry-feature-implement.yaml
@@ -24,6 +24,12 @@ jobs:
         python-version: '3.12'
     - name: Install Claude Code
       run: npm install -g @anthropic-ai/claude-code
+    - name: Prime Claude Code onboarding
+      # Without this, claude -p tries to render the theme picker TUI and
+      # aborts with "Raw mode is not supported" — see anthropics/claude-code#8938.
+      run: |
+        mkdir -p ~/.claude
+        echo '{"hasCompletedOnboarding": true}' > ~/.claude.json
     - name: Install agentry
       run: pip install "agentry @ git+https://github.com/norrietaylor/agentry.git"
     - name: Implement feature

--- a/.github/workflows/agentry-triage.yaml
+++ b/.github/workflows/agentry-triage.yaml
@@ -20,6 +20,12 @@ jobs:
         python-version: '3.12'
     - name: Install Claude Code
       run: npm install -g @anthropic-ai/claude-code
+    - name: Prime Claude Code onboarding
+      # Without this, claude -p tries to render the theme picker TUI and
+      # aborts with "Raw mode is not supported" — see anthropics/claude-code#8938.
+      run: |
+        mkdir -p ~/.claude
+        echo '{"hasCompletedOnboarding": true}' > ~/.claude.json
     - name: Install agentry
       run: pip install "agentry @ git+https://github.com/norrietaylor/agentry.git"
     - name: Run planning pipeline


### PR DESCRIPTION
The agentry code-review workflow has been failing on every run with `agent execution failed: Exit code 1`, and the triage/planning-pipeline runs have been quietly reporting every node as failed while the job still shows green (composition pipelines don't propagate node failures to the shell exit code).

Root cause is anthropics/claude-code#8938: `CLAUDE_CODE_OAUTH_TOKEN` on its own is not enough on a fresh runner. Claude Code also checks `~/.claude.json` for `hasCompletedOnboarding`, and when that's missing it tries to render the theme-picker TUI. On a headless runner that aborts immediately with `Raw mode is not supported on the current process.stdin`, the claude subprocess exits 1, and agentry surfaces it as a generic "agent execution failed".

This adds a one-line prime step to each of the four agentry workflows that writes `{"hasCompletedOnboarding": true}` to `~/.claude.json` before invoking agentry, so `claude -p` can skip onboarding entirely and go straight to the work.

The `Agentry: Code Review` job on this PR is the canary — if it lands green and actually emits structured findings, A is the full fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to pre-initialize the Claude Code environment and mark onboarding as completed so tooling no longer triggers interactive onboarding prompts; improves reliability of bug fixes, code reviews, feature runs, and triage jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->