### PR TITLE
chore(ci): add markdownlint pre-commit hook

### DIFF
--- a/.github/prompts/triage-distillery.md
+++ b/.github/prompts/triage-distillery.md
@@ -107,9 +107,10 @@ the exact failure mode this contract exists to prevent. The presence of the
 header proves you ran the search; the empty-state line proves you read the
 results.
 
-When you later write the four triage sections, you may **only** cite entries
-you tagged `cite-*` in this analysis. Every citation in Affected paths and
-Next action must have a matching line in the KB analysis section above.
+When you later write the four sections that follow KB analysis (Severity,
+Category, Affected paths, Next action), you may **only** cite entries you
+tagged `cite-*` in this analysis. Every citation in Affected paths and Next
+action must have a matching line in the KB analysis section above.
 
 ### Example `## KB analysis` section
 

--- a/.github/prompts/triage.md
+++ b/.github/prompts/triage.md
@@ -20,7 +20,9 @@ Start this section with exactly one of these four tokens, wrapped in
 backticks, with no bold, italics, quotes, period, or any other punctuation
 attached to the token itself:
 
-    `critical`  `high`  `medium`  `low`
+```text
+`critical`  `high`  `medium`  `low`
+```
 
 After the backticked token, on the same line, an em-dash and a one-sentence
 justification grounded in concrete user-visible impact to people running
@@ -36,7 +38,9 @@ Elasticsearch nodes, causing full cluster downtime.
 Start with exactly one of these four tokens, wrapped in backticks, same
 formatting rules as severity:
 
-    `bug`  `feature`  `chore`  `docs`
+```text
+`bug`  `feature`  `chore`  `docs`
+```
 
 Then an em-dash and one short sub-flavour sentence if useful (e.g.
 "bug — molecule coverage gap", "chore — CI tuning"). No more.

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,28 @@
+# Markdownlint config — narrow scope by intent.
+#
+# We turn off the default rule set and re-enable only the rules that
+# CodeRabbit's CHILL profile flags on this repo. The goal is to catch
+# the same nits CodeRabbit catches, locally at commit time, without
+# generating a wall of false positives on the existing markdown that
+# was written without lint discipline.
+#
+# Add more rules here as the need is demonstrated, not preemptively.
+config:
+  default: false
+  MD040: true   # fenced-code-language: opening fences must specify a language
+  MD046:        # code-block-style: prefer fenced over indented
+    style: fenced
+
+# Narrow scope for the initial rollout: lint files this PR has touched
+# (the prompts directory). Expand to docs/, plugins/, tests/ in a follow-up
+# cleanup PR — running --all-files today reports 24 pre-existing findings
+# in unrelated files, which would block every commit if globbed in.
+globs:
+  - ".github/prompts/**/*.md"
+
+ignores:
+  - ".venv/**"
+  - "venv/**"
+  - "node_modules/**"
+  - ".ansible/**"
+  - ".claude/**"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,11 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - ansible
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.22.0
+    hooks:
+      - id: markdownlint-cli2
+        # Globs are driven entirely by .markdownlint-cli2.yaml so the hook
+        # has a consistent scope whether invoked by pre-commit or by hand.
+        pass_filenames: false


### PR DESCRIPTION
Adds `markdownlint-cli2` as a pre-commit hook so the MD040/MD046 nits CodeRabbit kept catching on #123 get caught locally at commit time. Scope is narrowed to `.github/prompts/**/*.md` for now via `.markdownlint-cli2.yaml` — the `docs/`, `plugins/`, and `tests/` trees have 24 pre-existing findings of the same kind that belong in a separate cleanup PR. The hook is glob-driven (`pass_filenames: false`) so the scope is the same whether pre-commit invokes it or someone runs it by hand.

While here, fixes the two MD046 violations in the base `triage.md` (severity and category token blocks were indented, now fenced as text) and tightens one ambiguous reference in `triage-distillery.md` to "the four triage sections" — now spells out which four follow KB analysis.

This is the followup to #123 that came out of the round-by-round CodeRabbit loop on that PR. The bigger systemic fix lives in `~/.claude/CLAUDE.md` (out of repo): a new "Code Review Feedback" section instructs Claude to grep for sibling instances of any reviewer-flagged issue before pushing the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added markdown linting configuration to enforce consistent code block formatting in documentation.
  * Integrated automated markdown validation through pre-commit hooks for improved documentation quality.

* **Documentation**
  * Enhanced triage documentation with clarified section requirements and strengthened citation rules for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->