### PR TITLE
fix(ci): grant id-token write to claude workflows

### DIFF
--- a/.github/workflows/claude-triage.yaml
+++ b/.github/workflows/claude-triage.yaml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   issues: write
+  id-token: write  # Required by anthropics/claude-code-action for OIDC auth
 
 concurrency:
   group: claude-triage-${{ github.event.issue.number || inputs.issue_number }}

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -52,6 +52,7 @@ jobs:
       pull-requests: read
       issues: read
       actions: read # Required for Claude to read CI results on PRs
+      id-token: write # Required by anthropics/claude-code-action for OIDC auth
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
anthropics/claude-code-action@v1 requests a GitHub OIDC token to authenticate to Anthropic, so the workflow needs id-token: write even when we also pass claude_code_oauth_token. Without the permission the triage step aborts with "Could not fetch an OIDC token" before Claude runs. I only spotted this after an earlier unzip-missing failure on the runner host masked it — fixing that exposed the next layer.

Surfaced while investigating why issue #129 did not get a triage comment despite the maintainer-open gate firing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow permissions to support enhanced security and deployment capabilities.

---

**Note:** This release contains infrastructure updates with no direct impact on user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->