### PR TITLE
Gate PR CI behind a run label

### DIFF
--- a/.github/workflows/check_ci_coverage.yml
+++ b/.github/workflows/check_ci_coverage.yml
@@ -2,6 +2,7 @@
 name: Check CI coverage
 on:
   pull_request:
+    types: [labeled]
     paths:
       - 'molecule/**'
       - '.github/workflows/test_*.yml'
@@ -12,11 +13,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   check-ci-coverage:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/consume_ci_run_label.yml
+++ b/.github/workflows/consume_ci_run_label.yml
@@ -1,0 +1,20 @@
+---
+name: Consume CI run label
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  consume:
+    if: ${{ github.event.label.name == 'ci:run' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove ci:run label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh issue edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "ci:run"

--- a/.github/workflows/consume_ci_run_label.yml
+++ b/.github/workflows/consume_ci_run_label.yml
@@ -1,7 +1,7 @@
 ---
 name: Consume CI run label
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
 
 permissions:

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -13,6 +13,7 @@ on:
           - warning
           - debug
   pull_request:
+    types: [labeled]
   push:
     branches:
       - 'main'
@@ -25,11 +26,12 @@ permissions:
   security-events: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   kics:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/test_elasticsearch_custom_certs.yml
+++ b/.github/workflows/test_elasticsearch_custom_certs.yml
@@ -13,6 +13,7 @@ on:
           - warning
           - debug
   pull_request:
+    types: [labeled]
     paths:
       - 'roles/elasticsearch/**'
       - 'roles/elasticstack/**'
@@ -27,11 +28,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   lint_elasticsearch:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     uses: ./.github/workflows/test_linting.yml
     with:
       rolename: elasticsearch

--- a/.github/workflows/test_elasticsearch_modules.yml
+++ b/.github/workflows/test_elasticsearch_modules.yml
@@ -13,6 +13,7 @@ on:
           - warning
           - debug
   pull_request:
+    types: [labeled]
     paths:
       - 'roles/elasticsearch/**'
       - 'roles/elasticstack/**'
@@ -27,11 +28,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   lint_elasticsearch:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     uses: ./.github/workflows/test_linting.yml
     with:
       rolename: elasticsearch

--- a/.github/workflows/test_elasticsearch_upgrade.yml
+++ b/.github/workflows/test_elasticsearch_upgrade.yml
@@ -13,6 +13,7 @@ on:
           - warning
           - debug
   pull_request:
+    types: [labeled]
     paths:
       - 'roles/elasticsearch/**'
       - 'roles/elasticstack/**'
@@ -26,11 +27,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   lint_elasticsearch:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     uses: ./.github/workflows/test_linting.yml
     with:
       rolename: elasticsearch

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -17,6 +17,7 @@ on:
         required: false
         type: string
   pull_request:
+    types: [labeled]
   merge_group:
   schedule:
     - cron: "0 4 * * 2,4,6"  # Tue/Thu/Sat — 48 jobs, alternate with ES/logstash
@@ -25,11 +26,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   changes:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     runs-on: ubuntu-latest
     outputs:
       should_test: ${{ steps.filter.outputs.should_test }}
@@ -196,7 +198,7 @@ jobs:
   full_stack_gate:
     runs-on: ubuntu-latest
     needs: [changes, lint_full, molecule_full_stack_every_os]
-    if: always()
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.label.name == 'ci:run') }}
     steps:
       - name: Check results
         run: |

--- a/.github/workflows/test_linting.yml
+++ b/.github/workflows/test_linting.yml
@@ -18,6 +18,7 @@ on:
         required: true
         type: string
   pull_request:
+    types: [labeled]
     branches:
       - '*'
 
@@ -26,6 +27,7 @@ permissions:
 
 jobs:
   lint:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     runs-on: self-hosted
     timeout-minutes: 10
     steps:

--- a/.github/workflows/test_plugins.yml
+++ b/.github/workflows/test_plugins.yml
@@ -13,6 +13,7 @@ on:
           - warning
           - debug
   pull_request:
+    types: [labeled]
     branches:
       - 'feature/**'
       - 'fix/**'
@@ -28,11 +29,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   pycodestyle:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     runs-on: self-hosted
     timeout-minutes: 15
     steps:

--- a/.github/workflows/test_role_beats.yml
+++ b/.github/workflows/test_role_beats.yml
@@ -13,6 +13,7 @@ on:
           - warning
           - debug
   pull_request:
+    types: [labeled]
     paths:
       - 'roles/beats/**'
       - 'roles/elasticstack/**'
@@ -27,11 +28,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   lint_beats:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     uses: ./.github/workflows/test_linting.yml
     with:
       rolename: beats

--- a/.github/workflows/test_role_elasticsearch.yml
+++ b/.github/workflows/test_role_elasticsearch.yml
@@ -13,6 +13,7 @@ on:
           - warning
           - debug
   pull_request:
+    types: [labeled]
     paths:
       - 'roles/elasticsearch/**'
       - 'roles/elasticstack/**'
@@ -27,11 +28,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   lint_elasticsearch:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     uses: ./.github/workflows/test_linting.yml
     with:
       rolename: elasticsearch

--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -13,6 +13,7 @@ on:
           - warning
           - debug
   pull_request:
+    types: [labeled]
     paths:
       - 'roles/kibana/**'
       - 'roles/elasticstack/**'
@@ -27,11 +28,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   lint_kibana:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     uses: ./.github/workflows/test_linting.yml
     with:
       rolename: kibana

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -13,6 +13,7 @@ on:
           - warning
           - debug
   pull_request:
+    types: [labeled]
     paths:
       - 'roles/logstash/**'
       - 'roles/elasticstack/**'
@@ -27,11 +28,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   lint_logstash:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     uses: ./.github/workflows/test_linting.yml
     with:
       rolename: logstash

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -13,6 +13,7 @@ on:
           - warning
           - debug
   pull_request:
+    types: [labeled]
     paths:
       - 'roles/repos/**'
       - 'roles/elasticstack/**'
@@ -27,11 +28,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.label.name != 'ci:run' && github.run_id || 'ci' }}
   cancel-in-progress: true
 
 jobs:
   lint_repos:
+    if: ${{ github.event_name != 'pull_request' || github.event.label.name == 'ci:run' }}
     uses: ./.github/workflows/test_linting.yml
     with:
       rolename: repos


### PR DESCRIPTION
## Summary
- require PR CI workflows to be triggered by adding the `ci:run` label
- keep schedule, workflow_dispatch, push, and merge_group behavior intact
- consume the `ci:run` label after it starts a CI run so follow-up pushes stay quiet

## Validation
- yamllint .github/workflows
- git diff --check

This lets review iteration continue without restarting the heavy CI set until the PR is ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manually trigger CI by applying the `ci:run` label to a pull request.
  * Automatic removal of the `ci:run` label after the run completes.

* **Chores**
  * CI workflows now respond to pull-request label events and gate jobs so they run only for non-PR events or PRs labeled `ci:run`.
  * Improved concurrency handling to reduce unwanted run cancellations and better isolate label-triggered runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->