### PR TITLE
fix(molecule): give repos_default enough memory for dnf on rockylinux9

### DIFF
--- a/molecule/repos_default/molecule.yml
+++ b/molecule/repos_default/molecule.yml
@@ -9,7 +9,10 @@ driver:
 platforms:
   - name: "repos-def-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     distro: "${MOLECULE_DISTRO:-debian12}"
-    memory_mb: 512
+    # 1024 MiB so dnf on rockylinux9 does not get OOM-killed during the
+    # security-packages install in the idempotence run. Every other
+    # scenario uses 2048+, this one was the outlier at 512.
+    memory_mb: 1024
 provisioner:
   name: ansible
   env:


### PR DESCRIPTION
repos_default was running with memory_mb: 512, which is tight enough that dnf on rockylinux9 gets OOM-killed during the security-packages install. The first converge squeaks by but the idempotence re-run triggers the kernel OOM-killer; Ansible reports rc: 137 / "No start of json char found" after three retries and the job fails. An earlier run on the same combo timed out at 30 minutes in idempotence — same root cause, different symptom depending on when the OOM-killer arrived.

Every other molecule scenario uses 2048+; 1024 is enough for a path that runs no services and keeps the container footprint modest.

I will kick off a workflow_dispatch of Test Role repos on this branch once merged to confirm the rockylinux9 + release 8 combo passes end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing infrastructure configuration to optimize test environment resource allocation and improve performance during automated testing runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->