### PR TITLE
debug(ci): enable show_full_output on claude-triage for one run

### DIFF
--- a/.github/workflows/claude-triage.yaml
+++ b/.github/workflows/claude-triage.yaml
@@ -67,4 +67,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: ${{ steps.prompt.outputs.body }}
+          # Temporary debug flag: exposes Claude's tool call inputs, outputs,
+          # and reasoning in the public Actions log so we can see why the
+          # permission_denials_count is non-zero and whether the triage
+          # comment is being produced. Revert after one debug triage.
+          show_full_output: true
           claude_args: --mcp-config ${{ runner.temp }}/distillery-mcp.json --allowedTools "Read,Grep,Glob,Bash(git:*),Bash(gh issue:*),Bash(gh search:*),Bash(gh api repos/Oddly/elasticstack/contents/*),mcp__distillery__distillery_search"


### PR DESCRIPTION
Temporary debug flag so I can see what Claude actually does during triage. The last run on #129 succeeded at SDK level but produced no issue comment and reported six permission denials, and under show_full_output: false the tool call inputs, outputs, and reasoning are all hidden from the Actions log.

Plan: merge this, run one debug triage, capture the full log, then flip the flag back to false in a follow-up commit. The allowedTools list keeps Claude to Read/Grep/Glob/git/gh on this public repo plus distillery_search, so the extra log surface is bounded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions workflow configuration to emit more detailed execution logs, providing improved visibility into automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->