### PR TITLE
ci: fix consume_ci_run_label permissions

### DIFF
--- a/.github/workflows/consume_ci_run_label.yml
+++ b/.github/workflows/consume_ci_run_label.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  issues: write
+  pull-requests: write
 
 jobs:
   consume:
@@ -17,4 +17,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh issue edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "ci:run"
+        run: gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --remove-label "ci:run"


### PR DESCRIPTION
The consume workflow has been failing on every invocation since it was added — all three recorded runs show `failure` with `GraphQL: Resource not accessible by integration (removeLabelsFromLabelable)`. Removing labels from a pull request needs `pull-requests: write`; the workflow was declaring `issues: write`. The `gh issue edit` route worked against the Issues REST API because PRs share numbering with issues, but GitHub's authorization check looks at the scope that matches the *target resource*, and for a PR that's `pull-requests`. I've swapped the permission and moved the command to `gh pr edit` so the intent lines up with the scope.

The practical effect of the bug: the `ci:run` label was never being auto-stripped after a run started. Heavy CI still fired (because the `pull_request: types: [labeled]` trigger on the test workflows doesn't depend on consume), but the label lingered, which meant subsequent pushes needed a manual remove-then-re-add to re-trigger. This fix restores the intended "label-then-forget" flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for improved CI/CD process management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->