### PR TITLE
fix(elasticsearch): drop dict-literal default from restart handler conditionals

### DIFF
--- a/roles/elasticsearch/handlers/main.yml
+++ b/roles/elasticsearch/handlers/main.yml
@@ -7,8 +7,8 @@
   when:
     - not ansible_check_mode
     - elasticsearch_enable | bool
-    - not (_elasticsearch_freshstart | default({'changed': false})).changed | bool
-    - not (_elasticsearch_freshstart_security | default({'changed': false})).changed | bool
+    - not (_elasticsearch_freshstart.changed | default(false) | bool)
+    - not (_elasticsearch_freshstart_security.changed | default(false) | bool)
     - not _elasticsearch_rolling_upgrade_performed | default(false) | bool
 
 - name: Restart Elasticsearch directly
@@ -20,8 +20,8 @@
     - >
       elasticsearch_config_restart_strategy == 'direct'
       or groups[elasticstack_elasticsearch_group_name] | default([]) | length <= 1
-    - not (_elasticsearch_freshstart | default({'changed': false})).changed | bool
-    - not (_elasticsearch_freshstart_security | default({'changed': false})).changed | bool
+    - not (_elasticsearch_freshstart.changed | default(false) | bool)
+    - not (_elasticsearch_freshstart_security.changed | default(false) | bool)
     - not _elasticsearch_rolling_upgrade_performed | default(false) | bool
 
 - name: Clear direct Elasticsearch restart request
@@ -34,8 +34,8 @@
     - >
       elasticsearch_config_restart_strategy == 'direct'
       or groups[elasticstack_elasticsearch_group_name] | default([]) | length <= 1
-    - not (_elasticsearch_freshstart | default({'changed': false})).changed | bool
-    - not (_elasticsearch_freshstart_security | default({'changed': false})).changed | bool
+    - not (_elasticsearch_freshstart.changed | default(false) | bool)
+    - not (_elasticsearch_freshstart_security.changed | default(false) | bool)
     - not _elasticsearch_rolling_upgrade_performed | default(false) | bool
 
 - name: Restart Elasticsearch rolling
@@ -47,8 +47,8 @@
     - elasticsearch_enable | bool
     - elasticsearch_config_restart_strategy == 'rolling'
     - groups[elasticstack_elasticsearch_group_name] | default([]) | length > 1
-    - not (_elasticsearch_freshstart | default({'changed': false})).changed | bool
-    - not (_elasticsearch_freshstart_security | default({'changed': false})).changed | bool
+    - not (_elasticsearch_freshstart.changed | default(false) | bool)
+    - not (_elasticsearch_freshstart_security.changed | default(false) | bool)
     - not _elasticsearch_rolling_upgrade_performed | default(false) | bool
 
 - name: Restart kibana if available for elasticsearch certificates


### PR DESCRIPTION
Closes #139.

Ansible 2.19 tightened conditional evaluation so expressions like `default({'changed': false})` inside a `when:` clause now fail with `Conditional expressions must be strings.`. The restart handlers in #137 all used that pattern to guard against the freshstart facts being undefined. Swapped to an attribute-level default (`.changed | default(false) | bool`), which is semantically equivalent — both forms return `false` (don't block the restart) when the fact is undefined or when `.changed` is missing — and parses cleanly under both 2.18 and 2.19.

The `elasticsearch_default` scenario's `side_effect.yml` already exercises the Restart Elasticsearch handler end-to-end on a 2-node cluster, so the code path is covered. Note that CI still pins `ansible-core<2.19` because of the unrelated `role_path` scoping change blocking that upgrade, so 2.19-strict mode is not yet directly exercised by CI — the fix is equivalent on 2.18.

Scope is intentionally narrow to what #139 calls out. Other `default({})` usages (in `until:` clauses across tasks) use empty-dict literals, not key-value dicts, and haven't been reported as failing; leaving those alone until we can actually run 2.19 in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Elasticsearch restart handler conditions to ensure proper evaluation and execution during restart operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->