### PR TITLE
fix(elasticsearch): scope master count to the current play's hosts

### DIFF
--- a/molecule/elasticsearch_roles_calculation/converge.yml
+++ b/molecule/elasticsearch_roles_calculation/converge.yml
@@ -1,8 +1,33 @@
 ---
 # The workaround for arbitrarily named role directory is important because the git repo has one name and the role within it another
 # Found at: https://github.com/ansible-community/molecule/issues/1567#issuecomment-436876722
-- name: Converge
-  hosts: all
+- name: Converge primary cluster (3 master-eligible nodes)
+  hosts: elasticsearch
+  vars:
+    elasticstack_release: "{{ lookup('env', 'ELASTIC_RELEASE') | default('9', true) | int }}"
+    elasticsearch_node_types:
+      - master
+      - data
+    elasticsearch_heap: 1
+    elasticsearch_check_calculation: true
+    elasticstack_no_log: false
+  tasks:
+    - name: Include Elastics repos role
+      ansible.builtin.include_role:
+        name: oddly.elasticstack.repos
+    - name: Include Elasticsearch
+      ansible.builtin.include_role:
+        name: oddly.elasticstack.elasticsearch
+    - name: CI — set lenient disk watermarks
+      ansible.builtin.include_tasks: ../shared/set_ci_watermarks.yml
+
+# Second cluster, same run. Without the fix for #143, group_by from the
+# first play would have left 3 masters in elasticsearch_role_master; this
+# play would then see 3 + 1 = 4 masters and fail the odd-count assertion.
+# With the fix, the count is scoped to ansible_play_hosts_all, so this
+# cluster sees 1 master.
+- name: Converge monitoring cluster (1 master-eligible node, same run)
+  hosts: elasticsearch_mon
   vars:
     elasticstack_release: "{{ lookup('env', 'ELASTIC_RELEASE') | default('9', true) | int }}"
     elasticsearch_node_types:

--- a/molecule/elasticsearch_roles_calculation/molecule.yml
+++ b/molecule/elasticsearch_roles_calculation/molecule.yml
@@ -22,6 +22,14 @@ platforms:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"
     memory_mb: 4096
+  # Separate single-node "monitoring" cluster, run in a second play against
+  # this group to catch the regression from #143 where group_by accumulated
+  # elasticsearch_role_master across plays.
+  - name: "es-calc-mon-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
+    groups:
+      - elasticsearch_mon
+    distro: "${MOLECULE_DISTRO:-debian12}"
+    memory_mb: 4096
 provisioner:
   name: ansible
   env:

--- a/molecule/elasticsearch_roles_calculation/verify.yml
+++ b/molecule/elasticsearch_roles_calculation/verify.yml
@@ -2,9 +2,10 @@
 # The elasticsearch_check_calculation scenario only runs the node role
 # calculation logic, then exits via meta: end_host before installing ES.
 # The converge and idempotence phases already validate that the calculation
-# runs without error. There is no running cluster to verify.
+# runs without error across BOTH plays (primary + monitoring), which is the
+# regression guard for #143. There is no running cluster to verify.
 - name: Verify roles calculation completed
-  hosts: elasticsearch
+  hosts: elasticsearch:elasticsearch_mon
   tasks:
     - name: Confirm hosts are reachable (calculation mode does not install ES)
       ansible.builtin.ping:

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -126,7 +126,8 @@
 
     - name: Count master nodes
       ansible.builtin.set_fact:
-        elasticsearch_count_of_master_nodes: "{{ groups['elasticsearch_role_master'] | length }}"
+        elasticsearch_count_of_master_nodes: >-
+          {{ ansible_play_hosts_all | intersect(groups['elasticsearch_role_master'] | default([])) | length }}
 
     - name: Check count of master nodes
       ansible.builtin.fail:


### PR DESCRIPTION
Closes #143.

\`group_by\` accumulates into the global \`groups\` map across plays, so when the role runs against two separate clusters in the same \`ansible-playbook\` invocation (the reported case is a primary cluster plus a monitoring cluster), the second play sees every master-eligible node the run has touched — not just its own. A 3-node primary (odd, passes) followed by a 1-node monitor then trips the odd-count assertion at 4. Fix scopes the count via \`ansible_play_hosts_all | intersect(...)\` so each play evaluates only its own cluster.

To catch this in CI, extended \`molecule/elasticsearch_roles_calculation\` with a fourth host in a separate \`elasticsearch_mon\` group and a second play against that group. The scenario uses \`elasticsearch_check_calculation: true\` so it exits before installing ES — the added cost is one container, not a second cluster deploy. Without the fix, the second play sees 4 masters and fails; with the fix it sees 1 and passes.