### PR TITLE
fix(elasticsearch): respect user-supplied elasticsearch_cluster_set_up

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -76,19 +76,15 @@
   register: elasticsearch_cluster_setup_check
   failed_when: false
 
-- name: Set var that cluster is set up
+# Respect a user-supplied elasticsearch_cluster_set_up value (e.g. when joining
+# an existing multi-node cluster from a fresh node, the local marker file does
+# not exist but the user knows the cluster is already bootstrapped). Only
+# auto-detect via the marker file when the user has not set the variable.
+# See https://github.com/Oddly/elasticstack/issues/146 for context.
+- name: Set var that cluster is set up (auto-detect via marker file)
   ansible.builtin.set_fact:
-    elasticsearch_cluster_set_up: true
-  when:
-    - elasticsearch_cluster_setup_check is defined
-    - elasticsearch_cluster_setup_check.stat.exists | bool
-
-- name: Set var that cluster is not set up
-  ansible.builtin.set_fact:
-    elasticsearch_cluster_set_up: false
-  when:
-    - elasticsearch_cluster_setup_check is undefined or
-      not elasticsearch_cluster_setup_check.stat.exists | bool
+    elasticsearch_cluster_set_up: "{{ elasticsearch_cluster_setup_check.stat.exists | default(false) | bool }}"
+  when: elasticsearch_cluster_set_up is not defined
 
 - name: Check if master node count is correct
   when:


### PR DESCRIPTION
## Summary

Fixes #146.

The `elasticsearch` role overwrites `elasticsearch_cluster_set_up` unconditionally via `set_fact` based on a per-node marker file. When a fresh node joins an existing multi-node cluster, the marker file doesn't exist, so the variable is forced to `false` even if the user explicitly set it `true` in inventory. The template then emits `cluster.initial_master_nodes`, and the new node bootstraps its own single-node cluster instead of joining.

This PR makes the auto-detect `set_fact` only run when the user has not defined the variable themselves. Existing behaviour for users who don't set the variable is unchanged — the marker file is still consulted on first deploy.

## Change

Two `set_fact` tasks (one for `true`, one for `false`) collapsed into a single conditional task:

```yaml
- name: Set var that cluster is set up (auto-detect via marker file)
  ansible.builtin.set_fact:
    elasticsearch_cluster_set_up: \"{{ elasticsearch_cluster_setup_check.stat.exists | default(false) | bool }}\"
  when: elasticsearch_cluster_set_up is not defined
```

The second `set_fact` later in `main.yml` (after security setup, line ~580 — referencing #137) is unchanged: that one explicitly marks the cluster as set up after this node finishes its security configuration, which is correct behaviour for both new-cluster and join-existing-cluster paths.

## Test plan

- [x] Verified manually: a fresh node with `elasticsearch_cluster_set_up: true` in inventory now correctly omits `cluster.initial_master_nodes` from the rendered config and joins the existing cluster
- [ ] Existing molecule scenarios should still pass (no behaviour change for users who don't set the variable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Elasticsearch cluster configuration to respect user-defined settings while maintaining automatic setup detection when no custom configuration is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->