### PR TITLE
fix(elasticsearch): skip bootstrap-only checks when joining existing cluster

### DIFF
--- a/roles/elasticsearch/tasks/elasticsearch-security.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-security.yml
@@ -648,7 +648,15 @@
   when: elasticsearch_http_security
 
 - name: elasticsearch-security | Runtime cluster setup (requires running Elasticsearch)
-  when: not ansible_check_mode
+  # Runtime cluster setup uses the bootstrap password to seed the elastic user,
+  # built-in user passwords, etc. on a fresh cluster. When joining an existing
+  # cluster (elasticsearch_cluster_set_up: true) those are already part of the
+  # replicated cluster state, the bootstrap password is no longer accepted,
+  # and this whole block fails with "Bootstrap password authentication failed
+  # and this is not the CA host". See issue #148.
+  when:
+    - not ansible_check_mode
+    - not elasticsearch_cluster_set_up | bool
   block:
     - name: elasticsearch-security | Check for API with bootstrap password
       ansible.builtin.uri:

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -129,11 +129,17 @@
         elasticsearch_count_of_master_nodes: >-
           {{ ansible_play_hosts_all | intersect(groups['elasticsearch_role_master'] | default([])) | length }}
 
+    # The odd-master-count rule is required for a fresh-bootstrapped cluster
+    # to have a stable initial quorum. When joining an existing cluster
+    # (elasticsearch_cluster_set_up: true) the cluster already has its own
+    # master-eligible quorum independent of how many new nodes are added in
+    # this play, so the check is irrelevant and would block legitimate joins.
     - name: Check count of master nodes
       ansible.builtin.fail:
         msg: "There must be an odd count of master nodes. You have {{ elasticsearch_count_of_master_nodes }}"
       when:
         - elasticsearch_count_of_master_nodes | int % 2  == 0
+        - not elasticsearch_cluster_set_up | bool
 
     - name: End play in checks
       ansible.builtin.meta: end_host


### PR DESCRIPTION
## Summary

Fixes #148. Builds on the same pattern as #146 / #147 (respect `elasticsearch_cluster_set_up: true` to avoid bootstrap-only behaviour on join-existing-cluster nodes).

Two checks in the role would fail when a fresh node joins an existing cluster:

1. **Odd-master-count check** in \`tasks/main.yml\` — fails when \`--limit\` covers an even number of master-eligible hosts. The check is meaningful for fresh-bootstrap quorum, irrelevant when joining a cluster that already has its own quorum.
2. **Runtime cluster setup block** in \`tasks/elasticsearch-security.yml\` — tries to authenticate with \`elasticsearch_bootstrap_pw\` against the joining node's API. On an existing cluster the bootstrap password is no longer the elastic user's password (it has been replaced during the cluster's own initial setup, and replicates via cluster state), so the check fails after 30 retries with \`\"Bootstrap password authentication failed and this is not the CA host\"\`.

In both cases the joining node is in fact correctly added to the cluster (verifiable via \`_cat/nodes\`), so these checks are blocking a healthy outcome.

## Change

* \`tasks/main.yml\` — added \`- not elasticsearch_cluster_set_up | bool\` to the \`Check count of master nodes\` task's \`when\`. The count is still computed (might be useful elsewhere); only the failing check is suppressed when joining.
* \`tasks/elasticsearch-security.yml\` — added \`- not elasticsearch_cluster_set_up | bool\` to the \`Runtime cluster setup (requires running Elasticsearch)\` block's \`when\`. The whole block is bootstrap-only.

Comments added in both places explaining why.

## Test plan

- [x] Manual: with \`elasticsearch_cluster_set_up: true\` set and \`--limit\` to a single new master, role completes; node joins the existing cluster and the \`_cat/nodes\` listing includes it as expected.
- [x] Manual: same with two new masters in scope (even count) — no longer fails.
- [ ] Existing molecule scenarios should still pass (default \`elasticsearch_cluster_set_up\` flow is unchanged).

## Notes

These three issues (#146, #148) point to a common pattern: the role bundles \"first-time security bootstrap\" with normal config rendering. Long-term it might be worth splitting them into separate task files, but this minimal fix addresses the immediate blocker.