### PR TITLE
Revert "fix(elasticsearch): skip bootstrap-only checks when joining existing cluster (#149)"

### DIFF
--- a/roles/elasticsearch/tasks/elasticsearch-security.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-security.yml
@@ -648,15 +648,7 @@
   when: elasticsearch_http_security
 
 - name: elasticsearch-security | Runtime cluster setup (requires running Elasticsearch)
-  # Runtime cluster setup uses the bootstrap password to seed the elastic user,
-  # built-in user passwords, etc. on a fresh cluster. When joining an existing
-  # cluster (elasticsearch_cluster_set_up: true) those are already part of the
-  # replicated cluster state, the bootstrap password is no longer accepted,
-  # and this whole block fails with "Bootstrap password authentication failed
-  # and this is not the CA host". See issue #148.
-  when:
-    - not ansible_check_mode
-    - not elasticsearch_cluster_set_up | bool
+  when: not ansible_check_mode
   block:
     - name: elasticsearch-security | Check for API with bootstrap password
       ansible.builtin.uri:

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -125,17 +125,11 @@
         elasticsearch_count_of_master_nodes: >-
           {{ ansible_play_hosts_all | intersect(groups['elasticsearch_role_master'] | default([])) | length }}
 
-    # The odd-master-count rule is required for a fresh-bootstrapped cluster
-    # to have a stable initial quorum. When joining an existing cluster
-    # (elasticsearch_cluster_set_up: true) the cluster already has its own
-    # master-eligible quorum independent of how many new nodes are added in
-    # this play, so the check is irrelevant and would block legitimate joins.
     - name: Check count of master nodes
       ansible.builtin.fail:
         msg: "There must be an odd count of master nodes. You have {{ elasticsearch_count_of_master_nodes }}"
       when:
         - elasticsearch_count_of_master_nodes | int % 2  == 0
-        - not elasticsearch_cluster_set_up | bool
 
     - name: End play in checks
       ansible.builtin.meta: end_host


### PR DESCRIPTION
Reverts #149.

The block-level `when: not elasticsearch_cluster_set_up | bool` on the "Runtime cluster setup" block in `elasticsearch-security.yml` regresses fresh-install scenarios. The block contains an inner `set_fact` that flips `elasticsearch_cluster_set_up` to `true` partway through, after the initial passwords file is written. Ansible copies a block-level `when` onto every inner task and re-evaluates it against the current variable state, so every task after that internal set_fact silently skips — including `Fetch elastic password after initial setup`, which is what sets `elasticstack_password`. Downstream consumers (cluster settings, watermarks, the molecule shared `set_ci_watermarks` helper) then see `elasticstack_password` undefined and either fall back to a hardcoded path that doesn't exist for custom-path scenarios, or fail outright.

I caught this on a workflow_dispatch of `Test Role elasticsearch` against main after the merge: `elasticsearch_custom`, `elasticsearch_cert_content`, and `elasticsearch_diagnostics` failed at the watermark step on rocky9 + ES 9 (and debian13 for diagnostics). The same scenarios were green on the schedule run from yesterday, and main is exactly +2 commits since then (#147 + #149), confirming the regression source.

I'm reverting both files in #149 together. The `main.yml` master-count change isn't broken by itself, but it's only useful in combination with the join-existing-cluster path, so it goes back along with the security-tasks revert and returns in the follow-up PR.

A follow-up will replace this with task-level gating: add `not elasticsearch_cluster_set_up | bool` to the individual bootstrap-password tasks (`Check for API with bootstrap password`, the recovery sub-block, the `Fail` task, and `Check for cluster status with bootstrap password`) so they skip on a joining node without poisoning the inner set_fact. Reopens #148.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Refined Elasticsearch cluster setup execution logic to respect system check mode
  * Simplified master-node validation to consistently enforce odd-count requirement for cluster stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->