### PR TITLE
fix(elasticsearch): skip bootstrap-only checks when joining existing cluster

### DIFF
--- a/roles/elasticsearch/tasks/elasticsearch-security.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-security.yml
@@ -650,6 +650,18 @@
 - name: elasticsearch-security | Runtime cluster setup (requires running Elasticsearch)
   when: not ansible_check_mode
   block:
+    # Bootstrap-password tasks below are gated on
+    # `elasticsearch_cluster_set_up` so that a node joining an existing
+    # cluster (where the user signals `elasticsearch_cluster_set_up: true`)
+    # skips bootstrap-only checks. The bootstrap password is no longer
+    # accepted on an established cluster — replicated cluster state has
+    # replaced it — so running these checks on a joining node fails with
+    # "Bootstrap password authentication failed and this is not the CA
+    # host". See issue #148. Gated per task rather than at the block
+    # level because a later task in this block flips
+    # `elasticsearch_cluster_set_up` to true and Ansible re-evaluates
+    # block-level whens against the live variable, which would silently
+    # skip everything after that flip.
     - name: elasticsearch-security | Check for API with bootstrap password
       ansible.builtin.uri:
         url: "{{ elasticsearch_http_protocol }}://{{ elasticsearch_api_host }}:{{ elasticstack_elasticsearch_http_port }}"
@@ -662,6 +674,7 @@
       no_log: "{{ elasticstack_no_log }}"
       when:
         - not elasticsearch_passwords_file.stat.exists | bool
+        - not elasticsearch_cluster_set_up | bool
       until: (elasticsearch_api_status_bootstrap.json | default({})).cluster_name is defined
       retries: 30
       delay: 10
@@ -675,6 +688,7 @@
         - not elasticsearch_passwords_file.stat.exists | bool
         - elasticsearch_api_status_bootstrap is failed
         - inventory_hostname == elasticstack_ca_host
+        - not elasticsearch_cluster_set_up | bool
       block:
         - name: elasticsearch-security | Reset elastic user password via elasticsearch-reset-password
           ansible.builtin.command: >
@@ -727,6 +741,7 @@
         - not elasticsearch_passwords_file.stat.exists | bool
         - elasticsearch_api_status_bootstrap is failed
         - inventory_hostname != elasticstack_ca_host
+        - not elasticsearch_cluster_set_up | bool
 
     # We need this check twice. One to wait for the API to be actually available. And a second time to
     # check the actual return code. Should not cause a huge delay.
@@ -743,6 +758,7 @@
       no_log: "{{ elasticstack_no_log }}"
       when:
         - not elasticsearch_passwords_file.stat.exists | bool
+        - not elasticsearch_cluster_set_up | bool
       until: (elasticsearch_cluster_status_bootstrap.json | default({})).status | default('') in ["green", "yellow"]
       retries: 30
       delay: 10

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -125,11 +125,17 @@
         elasticsearch_count_of_master_nodes: >-
           {{ ansible_play_hosts_all | intersect(groups['elasticsearch_role_master'] | default([])) | length }}
 
+    # The odd-master-count rule is required for a fresh-bootstrapped cluster
+    # to have a stable initial quorum. When joining an existing cluster
+    # (elasticsearch_cluster_set_up: true) the cluster already has its own
+    # master-eligible quorum independent of how many new nodes are added in
+    # this play, so the check is irrelevant and would block legitimate joins.
     - name: Check count of master nodes
       ansible.builtin.fail:
         msg: "There must be an odd count of master nodes. You have {{ elasticsearch_count_of_master_nodes }}"
       when:
         - elasticsearch_count_of_master_nodes | int % 2  == 0
+        - not elasticsearch_cluster_set_up | bool
 
     - name: End play in checks
       ansible.builtin.meta: end_host


### PR DESCRIPTION
Reopens #148 after the first attempt (#149) was reverted in #150.

The previous attempt put the gate on the whole "Runtime cluster setup" block in `elasticsearch-security.yml`. That block contains an inner `set_fact` that flips `elasticsearch_cluster_set_up` to `true` partway through, after the initial passwords file is written. Ansible re-evaluates a block-level `when:` against each task's live variable state, so every task after that internal flip silently skipped — including `Fetch elastic password after initial setup`, which is what sets `elasticstack_password`. Downstream consumers (cluster settings, watermarks, the molecule shared `set_ci_watermarks` helper) then saw `elasticstack_password` undefined and either fell back to a hardcoded `/usr/share/elasticsearch/initial_passwords` path that doesn't exist on custom-path scenarios, or failed outright. CI on main caught it on `elasticsearch_custom`, `elasticsearch_cert_content`, and `elasticsearch_diagnostics`.

This version gates per task instead. Each of the four bootstrap-only tasks gets `- not elasticsearch_cluster_set_up | bool` added to its existing `when:` list (alongside `not elasticsearch_passwords_file.stat.exists | bool` which they all already had). Per-task `when:` is evaluated independently, so the inner `set_fact` doesn't poison subsequent tasks. The four gated tasks are `Check for API with bootstrap password`, the `Recover elastic user after interrupted security setup` sub-block, the `Fail if bootstrap password check failed and recovery was not attempted` task, and `Check for cluster status with bootstrap password`. A comment on the block explains why the gating is at task level rather than block level.

The master-count check in `main.yml` returns unchanged from #149 — it sits before the security tasks run and the inner flip never reaches it, so it was uncontroversial and just got reverted along with #149 for a clean rollback.

No molecule scenario exercises the join-existing-cluster path: it would need a multi-node setup where the joining node sees the passwords file as absent (stat delegated to the CA host), which single-node scenarios can't reproduce. Adding one is more disruptive than the fix warrants. The existing scenarios still validate the fresh-bootstrap regression class — they're what flagged #149's issue when I ran the full elasticsearch-role workflow against main, and they'll catch the same shape of regression on this PR too.