### PR TITLE
fix(elasticsearch): gate remaining tasks on check mode

### DIFF
--- a/roles/elasticsearch/handlers/main.yml
+++ b/roles/elasticsearch/handlers/main.yml
@@ -56,6 +56,7 @@
   loop: "{{ groups[elasticstack_kibana_group_name] | default([]) }}"
   run_once: true
   when:
+    - not ansible_check_mode
     - elasticstack_full_stack | bool
     - "not 'renew_ca' in ansible_run_tags"
     - "not elasticstack_ca_will_expire_soon | bool"

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -558,14 +558,15 @@
 # so the finding is a false positive
 
 - name: Handle cluster setup without security
-  when: not elasticsearch_security | bool
+  when:
+    - not elasticsearch_security | bool
+    - not ansible_check_mode
   block:
     - name: Check for cluster status without security
       ansible.builtin.uri:
 # kics-scan ignore-line
         url: "http://{{ elasticsearch_api_host }}:{{ elasticstack_elasticsearch_http_port }}/_cluster/health?pretty"
       register: elasticsearch_cluster_status
-      ignore_errors: "{{ ansible_check_mode }}"
       until: ((elasticsearch_cluster_status.json | default({})).status | default('')) in ['green', 'yellow']
       retries: 30
       delay: 10


### PR DESCRIPTION
Two paths in the elasticsearch role still ran (or wasted time) under \`--check\`.

The no-security cluster setup block in \`tasks/main.yml\` hit the cluster health API with \`ignore_errors: ansible_check_mode\`. The \`until\` loop (30 × 10s) still executed, so a check-mode pass burnt up to five minutes waiting on an endpoint that cannot respond without a running service. Moved the check-mode guard up to the block-level \`when\` so the whole branch is skipped, and dropped the now-redundant \`ignore_errors\`.

The handler that restarts Kibana after an Elasticsearch certificate change in \`handlers/main.yml\` had no check-mode guard, so it would attempt a service restart and HTTP probe against a Kibana that may not even be running. Added the same \`not ansible_check_mode\` condition the four neighbouring Elasticsearch restart handlers in this file already use.

No molecule scenario currently runs the role under \`--check\`, so I haven't added a verify-side test — adding a check-mode converge would be more invasive than the fix. The change has no behavioural impact on normal (non-check-mode) runs.

Closes #25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Ansible check mode handling by preventing unnecessary Kibana restarts and Elasticsearch health checks during validation runs.
  * Enhanced check-mode reliability by skipping operations that should not execute during dry runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->