### PR TITLE
feat(kibana): add kibana_public_base_url to override server.publicBaseUrl

### DIFF
--- a/molecule/kibana_custom/converge.yml
+++ b/molecule/kibana_custom/converge.yml
@@ -12,6 +12,7 @@
     # Kibana custom settings
     kibana_config_backup: true
     kibana_sniff_on_start: true
+    kibana_public_base_url: "https://kibana.example.com"
     kibana_extra_config: |-
       ops.interval: 10000
       logging.root.level: warn

--- a/molecule/kibana_custom/verify.yml
+++ b/molecule/kibana_custom/verify.yml
@@ -72,6 +72,13 @@
               - "'logging.root.level: warn' in (kibana_yml.content | b64decode)"
             fail_msg: "Extra config not found in kibana.yml"
 
+        - name: Verify kibana_public_base_url override is applied verbatim
+          ansible.builtin.assert:
+            that:
+              - "'server.publicBaseUrl: \"https://kibana.example.com\"' in (kibana_yml.content | b64decode)"
+              - "'kibana.example.com:5601' not in (kibana_yml.content | b64decode)"
+            fail_msg: "kibana_public_base_url override not honoured in kibana.yml"
+
         - name: Verify sniff on start is enabled (pre-9.x only)
           ansible.builtin.assert:
             that:

--- a/roles/kibana/defaults/main.yml
+++ b/roles/kibana/defaults/main.yml
@@ -74,6 +74,14 @@ kibana_tls_remote_src: false
 # @end
 # kibana_server_protocol: ""
 
+# @var kibana_public_base_url:description: >
+#   Explicit value for server.publicBaseUrl, used verbatim. Set this when Kibana
+#   runs behind a reverse proxy on a different host/port than the node itself
+#   (the generated default is "<scheme>://<host>:<port>"). Empty = use the
+#   generated default.
+# @end
+kibana_public_base_url: ""
+
 # @var kibana_sniff_on_start:description: >
 #   Discover all Elasticsearch nodes in the cluster on Kibana startup.
 #   Deprecated: removed in Elasticsearch/Kibana 9.x. Will be dropped in a future release.

--- a/roles/kibana/templates/kibana.yml.j2
+++ b/roles/kibana/templates/kibana.yml.j2
@@ -1,7 +1,11 @@
 {{ ansible_managed | comment }}
 
 server.host: "0.0.0.0"
+{% if kibana_public_base_url is defined and kibana_public_base_url | length > 0 %}
+server.publicBaseUrl: "{{ kibana_public_base_url }}"
+{% else %}
 server.publicBaseUrl: "http{% if kibana_tls | bool %}s{% endif %}://{{ elasticstack_kibana_host | default( ansible_facts.fqdn ) }}:{{ elasticstack_kibana_port }}"
+{% endif %}
 {% if kibana_server_protocol is defined and kibana_server_protocol | length > 0 %}
 server.protocol: "{{ kibana_server_protocol }}"
 {% endif %}


### PR DESCRIPTION
The kibana role derives `server.publicBaseUrl` as `<scheme>://<host>:<port>`, which is incorrect when Kibana runs behind a reverse proxy on a different host/port (generated report and alerting links point at the node instead of the proxy).

This adds an optional `kibana_public_base_url` variable, used verbatim when set. The default is empty, preserving the current generated value, so there is no behaviour change for existing users.

Coverage added to the `kibana_custom` molecule scenario: it sets the override and asserts the verbatim value is rendered and the `:5601` form is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting a custom public URL for Kibana.
  * The configured value is used as-is when provided, with a fallback to the automatically generated URL when left unset.

* **Bug Fixes**
  * Improved Kibana configuration handling to avoid adding an unexpected port to custom public URLs.
  * Expanded verification to confirm the configured URL appears correctly in the generated setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->