### PR TITLE
feat(kibana): allow supplying xpack encryption keys

### DIFF
--- a/molecule/kibana_custom/converge.yml
+++ b/molecule/kibana_custom/converge.yml
@@ -16,6 +16,8 @@
     # kibana_extra_config also sets it, to prove the managed key is filtered out there:
     # a duplicate server.publicBaseUrl makes Kibana refuse to start.
     kibana_public_base_url: "https://kibana.example.com"
+    kibana_security_encryptionkey: "moleculeProvidedSecurityKey0123456789abcd"
+    kibana_encryptedsavedobjects_encryptionkey: "moleculeProvidedSavedObjectsKey0123456789"
     kibana_extra_config: |-
       ops.interval: 10000
       logging.root.level: warn

--- a/molecule/kibana_custom/verify.yml
+++ b/molecule/kibana_custom/verify.yml
@@ -93,6 +93,24 @@
               - "(kibana_yml.content | b64decode | from_yaml) is mapping"
             fail_msg: "kibana.yml is not parseable as YAML"
 
+        - name: Read provided encryption keys from the keystore
+          ansible.builtin.command: >
+            /usr/share/kibana/bin/kibana-keystore show {{ item }}
+          environment:
+            KBN_PATH_CONF: /etc/kibana
+          loop:
+            - xpack.security.encryptionKey
+            - xpack.encryptedSavedObjects.encryptionKey
+          register: provided_keys
+          changed_when: false
+
+        - name: Verify provided encryption keys are honoured in the keystore
+          ansible.builtin.assert:
+            that:
+              - "provided_keys.results[0].stdout_lines[-1] == 'moleculeProvidedSecurityKey0123456789abcd'"
+              - "provided_keys.results[1].stdout_lines[-1] == 'moleculeProvidedSavedObjectsKey0123456789'"
+            fail_msg: "Provided encryption keys not stored in the Kibana keystore"
+
         - name: Verify sniff on start is enabled (pre-9.x only)
           ansible.builtin.assert:
             that:

--- a/roles/kibana/defaults/main.yml
+++ b/roles/kibana/defaults/main.yml
@@ -46,6 +46,22 @@ kibana_tls: false
 kibana_tls_key_passphrase: PleaseChangeMe
 # @var kibana_keystore_password:description: Password to encrypt the Kibana keystore file. Empty means no encryption (same as ES default)
 kibana_keystore_password: ""
+
+# @var kibana_security_encryptionkey:description: >
+#   Value for xpack.security.encryptionKey (stored in the Kibana keystore).
+#   Set this to reuse an existing key when migrating Kibana to a new host or
+#   running multiple instances, so encrypted session state stays valid. Empty
+#   generates a random key on first run.
+# @end
+kibana_security_encryptionkey: ""
+
+# @var kibana_encryptedsavedobjects_encryptionkey:description: >
+#   Value for xpack.encryptedSavedObjects.encryptionKey (stored in the keystore).
+#   Set this to reuse an existing key when migrating or scaling out, otherwise
+#   encrypted saved objects (alerting rules, connectors, Fleet tokens) cannot be
+#   decrypted by the new instance. Empty generates a random key on first run.
+# @end
+kibana_encryptedsavedobjects_encryptionkey: ""
 # @var kibana_cert_expiration_buffer:description: Days before certificate expiry to trigger renewal
 kibana_cert_expiration_buffer: 30
 # @var kibana_cert_validity_period:description: Validity period in days for generated TLS certificates

--- a/roles/kibana/tasks/kibana-security.yml
+++ b/roles/kibana/tasks/kibana-security.yml
@@ -292,6 +292,16 @@
       loop_control:
         label: "{{ item.item }}"
 
+    - name: kibana-security | Use provided encryption key
+      ansible.builtin.copy:
+        dest: "{{ elasticstack_ca_dir }}/encryption_key"
+        content: "{{ kibana_security_encryptionkey }}"
+        owner: root
+        group: elasticsearch
+        mode: "0600"
+      when: kibana_security_encryptionkey | default('') | length > 0
+      no_log: true
+
     - name: kibana-security | Generate encryption key
       ansible.builtin.shell: >
         set -o pipefail;
@@ -308,6 +318,16 @@
         src: "{{ elasticstack_ca_dir }}/encryption_key"
       register: kibana_encryption_key
       check_mode: false
+
+    - name: kibana-security | Use provided saved objects encryption key
+      ansible.builtin.copy:
+        dest: "{{ elasticstack_ca_dir }}/savedobjects_encryption_key"
+        content: "{{ kibana_encryptedsavedobjects_encryptionkey }}"
+        owner: root
+        group: elasticsearch
+        mode: "0600"
+      when: kibana_encryptedsavedobjects_encryptionkey | default('') | length > 0
+      no_log: true
 
     - name: kibana-security | Generate saved objects encryption key
       ansible.builtin.shell: >


### PR DESCRIPTION
The kibana role generates random `xpack.security.encryptionKey` and `xpack.encryptedSavedObjects.encryptionKey` on first run.

When migrating Kibana to a new host or running multiple instances, these keys must match the existing ones. Otherwise encrypted saved objects (alerting rules, connectors, Fleet tokens) and session state cannot be decrypted by the new instance.

This adds `kibana_security_encryptionkey` and `kibana_encryptedsavedobjects_encryptionkey` to supply the keys (written to the keystore via the existing flow). Both default to empty, preserving the generate-random behaviour, so there is no change for existing users. The `kibana_custom` molecule scenario sets both and asserts the provided values are stored in the keystore.