### PR TITLE
fix(kibana): compare keystore values by last output line

### DIFF
--- a/roles/kibana/tasks/kibana-keystore.yml
+++ b/roles/kibana/tasks/kibana-keystore.yml
@@ -108,7 +108,7 @@
     - kibana_security | bool
     - >-
       _kibana_ks_es_password.stdout is undefined or
-      kibana_password.stdout != _kibana_ks_es_password.stdout
+      kibana_password.stdout != (_kibana_ks_es_password.stdout_lines[-1] | default(''))
   notify:
     - Restart Kibana
 
@@ -156,7 +156,7 @@
       _kibana_ks_ssl_password.stdout is undefined or
       (kibana_tls_certificate_passphrase
        if kibana_cert_source == 'external' and _kibana_cert_format | default('') == 'p12'
-       else kibana_tls_key_passphrase) != _kibana_ks_ssl_password.stdout
+       else kibana_tls_key_passphrase) != (_kibana_ks_ssl_password.stdout_lines[-1] | default(''))
   notify:
     - Restart Kibana
 
@@ -199,7 +199,7 @@
     - kibana_security | bool
     - >-
       _kibana_ks_encryption_key.stdout is undefined or
-      (kibana_encryption_key.content | b64decode | trim) != _kibana_ks_encryption_key.stdout
+      (kibana_encryption_key.content | b64decode | trim) != (_kibana_ks_encryption_key.stdout_lines[-1] | default(''))
   notify:
     - Restart Kibana
 
@@ -229,7 +229,7 @@
     - kibana_security | bool
     - >-
       _kibana_ks_saved_objects_key.stdout is undefined or
-      (kibana_savedobjects_encryption_key.content | b64decode | trim) != _kibana_ks_saved_objects_key.stdout
+      (kibana_savedobjects_encryption_key.content | b64decode | trim) != (_kibana_ks_saved_objects_key.stdout_lines[-1] | default(''))
   notify:
     - Restart Kibana
 


### PR DESCRIPTION
`kibana-keystore show` can print a runtime warning on stdout before the value (for example the legacy OpenSSL provider notice). The keystore idempotency checks for `elasticsearch.password`, `server.ssl.keystore.password`, `xpack.security.encryptionKey` and `xpack.encryptedSavedObjects.encryptionKey` compared the desired value against the full `stdout`, so they never matched when a warning was present and the `kibana-keystore add` command ran on every play run.

Compare against the last line of the command output instead, which is the stored value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kibana keystore update checks so saved secrets are compared more reliably.
  * Reduced unnecessary configuration updates and restart triggers when keystore values have not changed.
  * Added safer handling for missing output during secret verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->