### PR TITLE
fix(kibana): make server.publicBaseUrl overridable via kibana_public_base_url

### DIFF
--- a/molecule/kibana_custom/converge.yml
+++ b/molecule/kibana_custom/converge.yml
@@ -12,6 +12,9 @@
     # Kibana custom settings
     kibana_config_backup: true
     kibana_sniff_on_start: true
+    # Override server.publicBaseUrl (e.g. a reverse proxy URL) via the dedicated var
+    # instead of a duplicate key in kibana_extra_config, which Kibana rejects.
+    kibana_public_base_url: "https://kibana.example.com"
     kibana_extra_config: |-
       ops.interval: 10000
       logging.root.level: warn

--- a/molecule/kibana_custom/converge.yml
+++ b/molecule/kibana_custom/converge.yml
@@ -20,6 +20,9 @@
       ops.interval: 10000
       logging.root.level: warn
       server.publicBaseUrl: "https://duplicate.example.com"
+      "server.host": "0.0.0.0"
+      elasticsearch.hosts:
+        - "https://should-be-filtered:9200"
   tasks:
     - name: Include Elastic repos
       ansible.builtin.include_role:

--- a/molecule/kibana_custom/converge.yml
+++ b/molecule/kibana_custom/converge.yml
@@ -12,12 +12,14 @@
     # Kibana custom settings
     kibana_config_backup: true
     kibana_sniff_on_start: true
-    # Override server.publicBaseUrl (e.g. a reverse proxy URL) via the dedicated var
-    # instead of a duplicate key in kibana_extra_config, which Kibana rejects.
+    # Override server.publicBaseUrl (e.g. a reverse proxy URL) via the dedicated var.
+    # kibana_extra_config also sets it, to prove the managed key is filtered out there:
+    # a duplicate server.publicBaseUrl makes Kibana refuse to start.
     kibana_public_base_url: "https://kibana.example.com"
     kibana_extra_config: |-
       ops.interval: 10000
       logging.root.level: warn
+      server.publicBaseUrl: "https://duplicate.example.com"
   tasks:
     - name: Include Elastic repos
       ansible.builtin.include_role:

--- a/molecule/kibana_custom/verify.yml
+++ b/molecule/kibana_custom/verify.yml
@@ -75,9 +75,13 @@
         - name: Verify server.publicBaseUrl uses the override and appears exactly once
           ansible.builtin.assert:
             that:
+              # The dedicated variable wins ...
               - "'server.publicBaseUrl: \"https://kibana.example.com\"' in (kibana_yml.content | b64decode)"
-              - "(kibana_yml.content | b64decode).split('\n') | select('match', '^server.publicBaseUrl:') | list | length == 1"
-            fail_msg: "server.publicBaseUrl override missing or duplicated in kibana.yml"
+              # ... the conflicting key from kibana_extra_config is filtered out ...
+              - "'duplicate.example.com' not in (kibana_yml.content | b64decode)"
+              # ... and the key is emitted exactly once (a duplicate stops Kibana from starting).
+              - "(kibana_yml.content | b64decode).split('\n') | select('match', '\\s*server\\.publicBaseUrl\\s*:') | list | length == 1"
+            fail_msg: "server.publicBaseUrl override missing, duplicated, or not filtered from kibana_extra_config"
 
         - name: Verify sniff on start is enabled (pre-9.x only)
           ansible.builtin.assert:

--- a/molecule/kibana_custom/verify.yml
+++ b/molecule/kibana_custom/verify.yml
@@ -72,6 +72,13 @@
               - "'logging.root.level: warn' in (kibana_yml.content | b64decode)"
             fail_msg: "Extra config not found in kibana.yml"
 
+        - name: Verify server.publicBaseUrl uses the override and appears exactly once
+          ansible.builtin.assert:
+            that:
+              - "'server.publicBaseUrl: \"https://kibana.example.com\"' in (kibana_yml.content | b64decode)"
+              - "(kibana_yml.content | b64decode).split('\n') | select('match', '^server.publicBaseUrl:') | list | length == 1"
+            fail_msg: "server.publicBaseUrl override missing or duplicated in kibana.yml"
+
         - name: Verify sniff on start is enabled (pre-9.x only)
           ansible.builtin.assert:
             that:

--- a/molecule/kibana_custom/verify.yml
+++ b/molecule/kibana_custom/verify.yml
@@ -81,7 +81,17 @@
               - "'duplicate.example.com' not in (kibana_yml.content | b64decode)"
               # ... and the key is emitted exactly once (a duplicate stops Kibana from starting).
               - "(kibana_yml.content | b64decode).split('\n') | select('match', '\\s*server\\.publicBaseUrl\\s*:') | list | length == 1"
+              # A quoted managed key must be filtered too (line-based filtering missed it).
+              - "(kibana_yml.content | b64decode).split('\n') | select('match', '\\s*.?server\\.host.?\\s*:') | list | length == 1"
+              # A multiline managed value must be removed whole, leaving no orphaned list items.
+              - "'should-be-filtered' not in (kibana_yml.content | b64decode)"
             fail_msg: "server.publicBaseUrl override missing, duplicated, or not filtered from kibana_extra_config"
+
+        - name: Verify kibana.yml is still valid YAML after filtering
+          ansible.builtin.assert:
+            that:
+              - "(kibana_yml.content | b64decode | from_yaml) is mapping"
+            fail_msg: "kibana.yml is not parseable as YAML"
 
         - name: Verify sniff on start is enabled (pre-9.x only)
           ansible.builtin.assert:

--- a/roles/kibana/defaults/main.yml
+++ b/roles/kibana/defaults/main.yml
@@ -5,6 +5,15 @@
 # Elasticsearch connection setup, and certificate management.
 # @end
 
+# === Server ===
+
+# @var kibana_public_base_url:description: >
+#   Value for server.publicBaseUrl. Defaults to this node's own URL. Set it to the
+#   externally reachable URL (e.g. the reverse proxy / VIP) when Kibana runs behind
+#   a proxy, so generated absolute URLs (reporting, share links) are correct.
+# @end
+kibana_public_base_url: "http{% if kibana_tls | bool %}s{% endif %}://{{ elasticstack_kibana_host | default(ansible_facts.fqdn) }}:{{ elasticstack_kibana_port }}"
+
 # === Node.js Memory ===
 
 # @var kibana_node_max_old_space_size:description: >

--- a/roles/kibana/templates/kibana.yml.j2
+++ b/roles/kibana/templates/kibana.yml.j2
@@ -42,10 +42,17 @@ server.ssl.keystore.path: "/etc/kibana/certs/{{ inventory_hostname }}-kibana.p12
 {% endif %}
 {% endif %}
 
+{# Filter kibana_extra_config to remove keys already managed by dedicated role variables. #}
+{# Kibana refuses to start on a duplicate key, so these must not be emitted twice.        #}
+{# _kibana_managed_keys is defined in vars/main.yml                                       #}
 {% if kibana_extra_config is defined and kibana_extra_config %}
 {% if kibana_extra_config is mapping %}
-{{ kibana_extra_config | to_nice_yaml(indent=2, sort_keys=False) }}
+{%   set _filtered = kibana_extra_config | dict2items | rejectattr('key', 'in', _kibana_managed_keys) | list | items2dict %}
+{%   if _filtered %}
+{{ _filtered | to_nice_yaml(indent=2, sort_keys=False) }}
+{%   endif %}
 {% else %}
-{{ kibana_extra_config }}
+{%   set _managed_pattern = '\s*(' ~ (_kibana_managed_keys | map('regex_escape') | join('|')) ~ ')\s*:' %}
+{{ kibana_extra_config.split('\n') | reject('match', _managed_pattern) | join('\n') }}
 {% endif %}
 {% endif %}

--- a/roles/kibana/templates/kibana.yml.j2
+++ b/roles/kibana/templates/kibana.yml.j2
@@ -42,17 +42,52 @@ server.ssl.keystore.path: "/etc/kibana/certs/{{ inventory_hostname }}-kibana.p12
 {% endif %}
 {% endif %}
 
-{# Filter kibana_extra_config to remove keys already managed by dedicated role variables. #}
-{# Kibana refuses to start on a duplicate key, so these must not be emitted twice.        #}
-{# _kibana_managed_keys is defined in vars/main.yml                                       #}
-{% if kibana_extra_config is defined and kibana_extra_config %}
-{% if kibana_extra_config is mapping %}
-{%   set _filtered = kibana_extra_config | dict2items | rejectattr('key', 'in', _kibana_managed_keys) | list | items2dict %}
-{%   if _filtered %}
-{{ _filtered | to_nice_yaml(indent=2, sort_keys=False) }}
-{%   endif %}
+{# Sleutels die dit template zelf schrijft. kibana_extra_config mag ze niet nogmaals    #}
+{# zetten: Kibana weigert te starten bij een dubbele sleutel. De condities hieronder     #}
+{# volgen exact de blokken hierboven, zodat alleen gefilterd wordt wat echt gerenderd is. #}
+{% set _managed = ['server.host', 'server.publicBaseUrl'] %}
+{% if kibana_server_protocol is defined and kibana_server_protocol | length > 0 %}
+{% set _managed = _managed + ['server.protocol'] %}
+{% endif %}
+{% if elasticstack_full_stack is defined and elasticstack_full_stack | bool %}
+{% set _managed = _managed + ['elasticsearch.hosts'] %}
+{% if kibana_sniff_on_start | bool and elasticstack_release | int < 9 %}
+{% set _managed = _managed + ['elasticsearch.sniffOnStart'] %}
+{% endif %}
+{% if kibana_sniff_on_connection_fault | bool and elasticstack_release | int < 9 %}
+{% set _managed = _managed + ['elasticsearch.sniffOnConnectionFault'] %}
+{% endif %}
+{% if kibana_sniff_interval is defined and elasticstack_release | int < 9 %}
+{% set _managed = _managed + ['elasticsearch.sniffInterval'] %}
+{% endif %}
+{% if kibana_security | bool %}
+{% set _managed = _managed + ['elasticsearch.username', 'elasticsearch.password'] %}
+{% if _kibana_has_ca | default(true) | bool %}
+{% set _managed = _managed + ['elasticsearch.ssl.certificateAuthorities'] %}
+{% endif %}
+{% if "localhost" in kibana_elasticsearch_hosts %}
+{% set _managed = _managed + ['elasticsearch.ssl.verificationMode'] %}
+{% endif %}
+{% endif %}
+{% endif %}
+{% if kibana_tls | bool %}
+{% set _managed = _managed + ['server.ssl.enabled'] %}
+{% if kibana_cert_source == 'external' and _kibana_cert_format | default('pem') == 'pem' %}
+{% set _managed = _managed + ['server.ssl.certificate', 'server.ssl.key'] %}
 {% else %}
-{%   set _managed_pattern = '\s*(' ~ (_kibana_managed_keys | map('regex_escape') | join('|')) ~ ')\s*:' %}
-{{ kibana_extra_config.split('\n') | reject('match', _managed_pattern) | join('\n') }}
+{% set _managed = _managed + ['server.ssl.keystore.path'] %}
+{% endif %}
+{% endif %}
+{# De string-vorm wordt als YAML geparsed i.p.v. per regel gefilterd: alleen zo worden   #}
+{# gequote sleutels en meerregelige waarden correct behandeld.                            #}
+{% if kibana_extra_config is defined and kibana_extra_config %}
+{% set _cfg = kibana_extra_config if kibana_extra_config is mapping else (kibana_extra_config | from_yaml) %}
+{% if _cfg is mapping %}
+{% set _filtered = _cfg | dict2items | rejectattr('key', 'in', _managed) | list | items2dict %}
+{% if _filtered %}
+{{ _filtered | to_nice_yaml(indent=2, sort_keys=False) }}
+{% endif %}
+{% else %}
+{{ kibana_extra_config }}
 {% endif %}
 {% endif %}

--- a/roles/kibana/templates/kibana.yml.j2
+++ b/roles/kibana/templates/kibana.yml.j2
@@ -1,7 +1,7 @@
 {{ ansible_managed | comment }}
 
 server.host: "0.0.0.0"
-server.publicBaseUrl: "http{% if kibana_tls | bool %}s{% endif %}://{{ elasticstack_kibana_host | default( ansible_facts.fqdn ) }}:{{ elasticstack_kibana_port }}"
+server.publicBaseUrl: "{{ kibana_public_base_url }}"
 {% if kibana_server_protocol is defined and kibana_server_protocol | length > 0 %}
 server.protocol: "{{ kibana_server_protocol }}"
 {% endif %}

--- a/roles/kibana/vars/main.yml
+++ b/roles/kibana/vars/main.yml
@@ -1,4 +1,22 @@
 ---
+# Keys managed by dedicated role variables in kibana.yml.j2. Used to filter
+# kibana_extra_config, since Kibana refuses to start on a duplicate key.
+_kibana_managed_keys:
+  - server.host
+  - server.publicBaseUrl
+  - server.protocol
+  - server.ssl.enabled
+  - server.ssl.certificate
+  - server.ssl.key
+  - server.ssl.keystore.path
+  - elasticsearch.hosts
+  - elasticsearch.username
+  - elasticsearch.password
+  - elasticsearch.ssl.certificateAuthorities
+  - elasticsearch.sniffOnStart
+  - elasticsearch.sniffOnConnectionFault
+  - elasticsearch.sniffInterval
+
 # Internal state — do not set manually
 kibana_cert_will_expire_soon: false
 

--- a/roles/kibana/vars/main.yml
+++ b/roles/kibana/vars/main.yml
@@ -1,22 +1,4 @@
 ---
-# Keys managed by dedicated role variables in kibana.yml.j2. Used to filter
-# kibana_extra_config, since Kibana refuses to start on a duplicate key.
-_kibana_managed_keys:
-  - server.host
-  - server.publicBaseUrl
-  - server.protocol
-  - server.ssl.enabled
-  - server.ssl.certificate
-  - server.ssl.key
-  - server.ssl.keystore.path
-  - elasticsearch.hosts
-  - elasticsearch.username
-  - elasticsearch.password
-  - elasticsearch.ssl.certificateAuthorities
-  - elasticsearch.sniffOnStart
-  - elasticsearch.sniffOnConnectionFault
-  - elasticsearch.sniffInterval
-
 # Internal state — do not set manually
 kibana_cert_will_expire_soon: false
 


### PR DESCRIPTION
Closes #164.

`server.publicBaseUrl` was hardcoded from `elasticstack_kibana_host | default(ansible_facts.fqdn)` and the port, so `kibana_public_base_url` was effectively unused and setting `server.publicBaseUrl` via `kibana_extra_config` produced a duplicate key that Kibana rejects on startup.

This drives `server.publicBaseUrl` from a new `kibana_public_base_url` default whose value reproduces the previous per-node behavior, so it stays backward-compatible and is now overridable for reverse-proxy / VIP setups.

Covered by the `kibana_custom` molecule scenario: it sets `kibana_public_base_url` and asserts the rendered `server.publicBaseUrl` matches the override and appears exactly once (guarding against the duplicate-key regression).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable public Kibana URL for accurate links when deployed behind a proxy.
  * Expanded custom Kibana configuration support for server host and Elasticsearch connection settings.

* **Bug Fixes**
  * Prevented duplicate managed settings from appearing in generated Kibana configuration.
  * Improved filtering of conflicting and multiline settings while preserving valid YAML output.

* **Tests**
  * Added validation for configuration filtering, duplicate prevention, and YAML validity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->