### PR TITLE
fix(ci): dedup KICS SARIF taxa before upload

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -51,6 +51,16 @@ jobs:
             --output-path /results \
             --report-formats json,sarif \
             --ignore-on-exit results
+
+      # Workaround for Checkmarx/kics#7588: repeated CWE findings cause KICS
+      # to emit duplicate entries in runs[].taxonomies[].taxa, which the SARIF
+      # schema (uniqueItems: true) rejects, blocking the upload step.
+      - name: Deduplicate SARIF taxa
+        run: |
+          jq '.runs |= map(.taxonomies |= (. // [] | map(.taxa |= (. // [] | unique_by(.id)))))' \
+            results-dir/results.sarif > results-dir/results.dedup.sarif
+          mv results-dir/results.dedup.sarif results-dir/results.sarif
+
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@af56b044b5d41c317aef5d19920b3183cb4fbbec # v3
         with:


### PR DESCRIPTION
KICS emits duplicate entries in `runs[].taxonomies[].taxa` when the same CWE is triggered by more than one finding. The SARIF schema requires `uniqueItems: true` on that array, so `github/codeql-action/upload-sarif` rejects the file and the KICS job ends red. This has been broken since the KICS release picked up the extra CWE-798 references from a couple of playbooks.

Upstream is aware in [Checkmarx/kics#7588](https://github.com/Checkmarx/kics/issues/7588), open since 2025-07 with no fix on the horizon, so I dedup the taxa arrays with jq between the scan and the upload. It preserves the first entry per id, leaves everything else untouched, and copes with `taxonomies` being null or missing.