### PR TITLE
fix(elasticsearch): detect external CA before the pre-upgrade config write

### DIFF
--- a/molecule/elasticsearch_upgrade_8to9_single/converge.yml
+++ b/molecule/elasticsearch_upgrade_8to9_single/converge.yml
@@ -19,7 +19,21 @@
     elasticstack_no_log: false
     elasticsearch_seed_hosts: []
     elasticsearch_initial_master_nodes: []
+    # External certificates, so the upgrade exercises the code path where
+    # elasticsearch.yml.j2 has to emit certificate_authorities. The multi-node
+    # elasticsearch_upgrade_8to9 scenario still covers the self-signed path.
+    elasticsearch_cert_source: external
+    elasticsearch_transport_tls_certificate: /tmp/test-certs/server.crt
+    elasticsearch_transport_tls_key: /tmp/test-certs/server.key
+    elasticsearch_http_tls_certificate: /tmp/test-certs/server.crt
+    elasticsearch_http_tls_key: /tmp/test-certs/server.key
+    elasticsearch_tls_ca_certificate: /tmp/test-certs/ca.crt
+    elasticsearch_tls_remote_src: true
+    elasticsearch_ssl_verification_mode: certificate
   tasks:
+    - name: Generate test certificates
+      ansible.builtin.include_tasks: ../shared/generate_test_certs.yml
+
     - name: Include Elastic repos role (8.x)
       ansible.builtin.include_role:
         name: oddly.elasticstack.repos
@@ -227,6 +241,17 @@
     elasticsearch_initial_master_nodes: []
     # Skip the countdown pause in CI
     elasticsearch_upgrade_countdown: 0
+    # Same external certificates as the install play; the rolling upgrade
+    # writes config before restarting, so this is where a missing
+    # certificate_authorities would be baked in.
+    elasticsearch_cert_source: external
+    elasticsearch_transport_tls_certificate: /tmp/test-certs/server.crt
+    elasticsearch_transport_tls_key: /tmp/test-certs/server.key
+    elasticsearch_http_tls_certificate: /tmp/test-certs/server.crt
+    elasticsearch_http_tls_key: /tmp/test-certs/server.key
+    elasticsearch_tls_ca_certificate: /tmp/test-certs/ca.crt
+    elasticsearch_tls_remote_src: true
+    elasticsearch_ssl_verification_mode: certificate
   tasks:
     - name: Include Elastic repos role (9.x)
       ansible.builtin.include_role:

--- a/molecule/elasticsearch_upgrade_8to9_single/verify.yml
+++ b/molecule/elasticsearch_upgrade_8to9_single/verify.yml
@@ -72,6 +72,26 @@
         fail_msg: "Test data corrupted or lost during upgrade!"
         success_msg: "Data preserved: {{ test_doc.json._source }}"
 
+    # Regression: the rolling upgrade writes elasticsearch.yml before restarting.
+    # The CA detection used to run after that write, so the fact gating the
+    # certificate_authorities lines was still unset and the template silently
+    # dropped them. The node then came up trusting no CA and could not rejoin.
+    - name: Read elasticsearch.yml after the upgrade
+      ansible.builtin.slurp:
+        src: /etc/elasticsearch/elasticsearch.yml
+      register: _es_yml
+
+    - name: Verify the external CA survived the rolling upgrade
+      ansible.builtin.assert:
+        that:
+          - "'xpack.security.transport.ssl.certificate_authorities' in (_es_yml.content | b64decode)"
+          - "'xpack.security.http.ssl.certificate_authorities' in (_es_yml.content | b64decode)"
+        fail_msg: >-
+          certificate_authorities missing from elasticsearch.yml after the
+          upgrade. The node cannot verify its peers and will not rejoin a
+          multi-node cluster.
+        success_msg: "External CA still configured after the upgrade"
+
     - name: Summary
       ansible.builtin.debug:
         msg: |

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -236,6 +236,28 @@
     - ansible_facts.packages['elasticsearch'] is defined
   run_once: true
 
+# Pre-detect external cert state so the template renders consistently
+# across first and subsequent runs (idempotency). This must happen before the
+# pre-upgrade config write below: elasticsearch.yml.j2 only emits
+# xpack.security.{transport,http}.ssl.certificate_authorities when
+# _elasticsearch_external_has_ca is true, and that fact defaults to false.
+# If it is still unset when the pre-upgrade config is written, the node
+# restarts into a config that trusts no CA and can no longer join the cluster.
+- name: Detect existing external CA for template rendering
+  ansible.builtin.stat:
+    path: /etc/elasticsearch/certs/ca.crt
+  register: _elasticsearch_existing_ca_cert
+  when: elasticsearch_cert_source == 'external'
+
+- name: Set external CA availability for initial template render
+  ansible.builtin.set_fact:
+    _elasticsearch_external_has_ca: true
+  when:
+    - elasticsearch_cert_source == 'external'
+    - (_elasticsearch_existing_ca_cert.stat.exists | default(false)) or
+      (elasticsearch_tls_ca_certificate | default('') | length > 0) or
+      (elasticsearch_tls_ca_certificate_content | default('') | length > 0)
+
 # Write config files BEFORE the rolling upgrade so the upgrade restart picks
 # up new config in a single restart. Without this, the rolling upgrade restarts
 # with old config, then config tasks change files and notify the handler,
@@ -352,23 +374,6 @@
     - not (_elasticsearch_needs_rolling_upgrade | bool)
     - _elasticsearch_package_upgraded | default(false) | bool
     - elasticstack_password.stdout is defined
-
-# Pre-detect external cert state so the template renders consistently
-# across first and subsequent runs (idempotency).
-- name: Detect existing external CA for template rendering
-  ansible.builtin.stat:
-    path: /etc/elasticsearch/certs/ca.crt
-  register: _elasticsearch_existing_ca_cert
-  when: elasticsearch_cert_source == 'external'
-
-- name: Set external CA availability for initial template render
-  ansible.builtin.set_fact:
-    _elasticsearch_external_has_ca: true
-  when:
-    - elasticsearch_cert_source == 'external'
-    - (_elasticsearch_existing_ca_cert.stat.exists | default(false)) or
-      (elasticsearch_tls_ca_certificate | default('') | length > 0) or
-      (elasticsearch_tls_ca_certificate_content | default('') | length > 0)
 
 - name: Warn about conflicting keys in elasticsearch_extra_config
   ansible.builtin.debug:


### PR DESCRIPTION
## Problem

A rolling upgrade writes `elasticsearch.yml` before restarting the node, so the
restart picks up the new config in one go. But the fact that gates the CA lines
in the template was set roughly a hundred lines *after* that write:

- `Configure Elasticsearch (pre-upgrade)` — `tasks/main.yml:246`
- `Set external CA availability for initial template render` — `tasks/main.yml:364`

`elasticsearch.yml.j2` only emits
`xpack.security.{transport,http}.ssl.certificate_authorities` when
`_elasticsearch_external_has_ca` is true, and that check is
`| default(false)`. During the pre-upgrade write the fact is still unset, so
both lines are silently dropped.

The node then restarts into a config that trusts no CA, fails the TLS handshake
against its peers and never rejoins:

```
o.e.d.PeerFinder address [10.0.0.2:9300], node [unknown] discovery result:
connect_exception: (certificate_unknown) PKIX path building failed:
unable to find valid certification path to requested target
```

The failure is quiet. The package installs, the service starts, systemd reports
`active`. The playbook only fails ~13 minutes later on
`Confirm the node joins the cluster`, and `no_log` hides the reason. Meanwhile
the aborted run leaves `cluster.routing.allocation.enable: primaries` and ML
upgrade mode behind, so the cluster stays yellow with unassigned replicas.

Re-running the role does not repair it either: the config is rewritten
correctly, but the restart is gated on cluster health that cannot recover while
this node is out — so the node needs a manual restart.

## Scope

Only `elasticsearch_cert_source: external` **and** PEM format is affected. With
p12 the template takes the keystore/truststore branch, where the trust chain
lives inside the p12 and there is no separate CA line to lose. That is why the
existing upgrade scenarios pass: they use the role's own self-signed p12 certs
and never reach the affected branch.

## Fix

Move the two CA-detection tasks ahead of the pre-upgrade config write. No logic
changed, only ordering.

This does not affect a first run. `elasticsearch-security.yml`, which places
`certs/ca.crt`, is imported at `tasks/main.yml:512` — after both the old and the
new position. On a fresh install the stat is false either way, and the
`elasticsearch_tls_ca_certificate` / `_content` conditions cover that case as
before.

## Test

`elasticsearch_upgrade_8to9_single` now uses external PEM certificates, built
with the existing `molecule/shared/generate_test_certs.yml`, and asserts that
both `certificate_authorities` lines survive the upgrade. The multi-node
`elasticsearch_upgrade_8to9` scenario keeps covering the self-signed path, so no
coverage is lost.

## Verification

Measured against a real 9-node cluster with FreeIPA-issued PEM certificates, by
running the elasticsearch play in `--check --diff` against a node that still
needed the upgrade:

| collection | pre-upgrade render |
|---|---|
| without the fix | removes `transport.ssl.certificate_authorities` and `http.ssl.certificate_authorities` |
| with the fix | no diff, both lines retained |

Molecule was not run: the self-hosted `incus-ci` runners are offline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Elasticsearch 8-to-9 upgrades using externally supplied TLS certificates.
  * Preserved external certificate-authority settings for both transport and HTTP connections throughout upgrades.
  * Added validation to detect missing CA configuration after an upgrade and report rejoin-related failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->