### PR TITLE
fix(ci): make memory-gate visible, fail loudly, stop starving roles_calculation

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -36,6 +36,12 @@ jobs:
     env:
       COLLECTION_NAMESPACE: oddly
       COLLECTION_NAME: elasticstack
+      # Ansible/molecule are Python; without PYTHONUNBUFFERED the
+      # "FAILED - RETRYING (N retries left)" messages that Ansible emits
+      # from the wait-for-capacity retry loop sit in Python's stdout
+      # buffer and only flush when the buffer fills, making the log look
+      # like a silent hang for tens of minutes.
+      PYTHONUNBUFFERED: '1'
       ANSIBLE_PIPELINING: 'true'
       ANSIBLE_GATHERING: smart
       ANSIBLE_ANY_ERRORS_FATAL: 'true'

--- a/.github/workflows/test_elasticsearch_upgrade.yml
+++ b/.github/workflows/test_elasticsearch_upgrade.yml
@@ -112,6 +112,9 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan -t ed25519 ${{ secrets.INCUS_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
 
+      - name: Acquire memory slot
+        run: bash scripts/wait-for-memory.sh acquire "${{ matrix.scenario }}" 1800
+
       - name: Test with molecule
         run: molecule test -s ${{ matrix.scenario }} --destroy=never
         env:
@@ -124,6 +127,10 @@ jobs:
           INCUS_HOST: ${{ secrets.INCUS_HOST }}
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
+
+      - name: Release memory slot
+        if: always()
+        run: bash scripts/wait-for-memory.sh release
 
       - name: Collect and upload diagnostics
         if: failure()
@@ -227,6 +234,9 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan -t ed25519 ${{ secrets.INCUS_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
 
+      - name: Acquire memory slot
+        run: bash scripts/wait-for-memory.sh acquire "${{ matrix.scenario }}" 1800
+
       - name: Test with molecule
         run: molecule test -s ${{ matrix.scenario }} --destroy=never
         env:
@@ -239,6 +249,10 @@ jobs:
           INCUS_HOST: ${{ secrets.INCUS_HOST }}
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
+
+      - name: Release memory slot
+        if: always()
+        run: bash scripts/wait-for-memory.sh release
 
       - name: Collect and upload diagnostics
         if: failure()

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -153,6 +153,14 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan -t ed25519 ${{ secrets.INCUS_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
 
+      - name: Acquire memory slot
+        # Coordinated admission gate — reserves the scenario's memory_mb on
+        # the shared incus-ci host so the biggest scenarios don't trample
+        # each other or the parallel test_role_* / test_elasticsearch_*
+        # workflows. This step was missing from the standalone workflow;
+        # the reusable molecule.yml wrapper has always had it.
+        run: bash scripts/wait-for-memory.sh acquire "${{ matrix.scenario }}" 1800
+
       - name: Converge
         run: molecule converge -s ${{ matrix.scenario }}
         env:
@@ -190,6 +198,13 @@ jobs:
           INCUS_HOST: ${{ secrets.INCUS_HOST }}
           MOLECULE_SSH_KEY: ${{ runner.temp }}/molecule_id_ed25519
           DISTRO_CACHE_URL: http://${{ secrets.REGISTRY_HOST }}:8081
+
+      - name: Release memory slot
+        # Runs whether converge/verify/idempotence passed or failed, so the
+        # reservation is freed promptly. Stale reservations (>1h) are also
+        # GC'd by the next acquire under the same lock as a safety net.
+        if: always()
+        run: bash scripts/wait-for-memory.sh release
 
       - name: Collect and upload diagnostics
         if: failure()

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -63,7 +63,13 @@ jobs:
     runs-on: self-hosted
     needs: [changes, lint_full]
     if: needs.changes.outputs.should_test == 'true' || github.event_name != 'pull_request'
-    timeout-minutes: 120
+    # 180 min: elasticstack_default is the heaviest scenario and observed
+    # runs range 70-105 min in isolation, but the extra queue wait added
+    # by the memory-capacity gate on a busy runner can push a single job
+    # past the previous 120-min cap.  The memory-gate retry cap in
+    # shared/create.yml is now 15 min so this ceiling is only reached
+    # when the scenario genuinely runs long, not when the queue starves it.
+    timeout-minutes: 180
 
     env:
       COLLECTION_NAMESPACE: oddly

--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -91,6 +91,13 @@ jobs:
 
     strategy:
       fail-fast: false
+      # Each scenario/distro/release combo needs 15-25 GB of container RAM on
+      # the shared incus-ci host. The memory-capacity gate in shared/create.yml
+      # eventually admits every job, but without a matrix-level cap the full
+      # 16-combo PR matrix would swamp the 131 GB host and starve the biggest
+      # scenarios (elasticstack_default, cert_renewal). 6 concurrent slots keep
+      # committed memory around 90-100 GB with head-room to spare.
+      max-parallel: 6
       matrix:
         distro: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && fromJSON('["rockylinux9","debian13"]') || (inputs.distros != '' && fromJSON(inputs.distros)) || fromJSON('["rockylinux9","ubuntu2204","ubuntu2404","ubuntu2604","debian12","debian13"]') }}
         scenario:

--- a/molecule/elasticsearch_roles_calculation/molecule.yml
+++ b/molecule/elasticsearch_roles_calculation/molecule.yml
@@ -7,21 +7,26 @@ dependency:
 driver:
   name: default
 platforms:
+  # 2 GB per container: the scenario runs elasticsearch_heap: 1 (= 1 GB)
+  # and only exercises the role-count-calculation code path, not any
+  # ingest workload. The default 4 GB was making the 16 GB total block
+  # the memory-capacity gate under peak concurrency and starve the
+  # scenario until the 45-min workflow timeout cancelled it.
   - name: "es-calc1-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"
-    memory_mb: 4096
+    memory_mb: 2048
   - name: "es-calc2-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"
-    memory_mb: 4096
+    memory_mb: 2048
   - name: "es-calc3-${MOLECULE_DISTRO:-debian12}-r${ELASTIC_RELEASE:-9}${MOLECULE_RUN_SUFFIX}"
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"
-    memory_mb: 4096
+    memory_mb: 2048
   # Separate single-node "monitoring" cluster, run in a second play against
   # this group to catch the regression from #143 where group_by accumulated
   # elasticsearch_role_master across plays.
@@ -29,7 +34,7 @@ platforms:
     groups:
       - elasticsearch_mon
     distro: "${MOLECULE_DISTRO:-debian12}"
-    memory_mb: 4096
+    memory_mb: 2048
 provisioner:
   name: ansible
   env:

--- a/molecule/shared/create.yml
+++ b/molecule/shared/create.yml
@@ -126,7 +126,14 @@
         REMOTE_SCRIPT
       changed_when: true
       register: _launch_result
-      retries: 360
+      # 30 retries × 30s = 15 min. Deliberately shorter than the workflow
+      # timeout (45 min for the standard molecule.yml call, 120 min for
+      # full_stack) so the task fails loudly with the last "No capacity:
+      # …" stdout instead of being silently cancelled by the workflow
+      # timeout — that made the queue-starvation cases very hard to
+      # diagnose (see PR investigating the elasticsearch_roles_calculation
+      # / elasticstack_default post-outage hangs).
+      retries: 30
       delay: 30
       until: _launch_result.rc == 0
 


### PR DESCRIPTION
While chasing the post-outage "elasticsearch_roles_calculation" cancellations on #155, I ended up finding that the memory-based capacity gate was doing three things wrong in combination.

The retry loop in `molecule/shared/create.yml` is set to `retries: 360, delay: 30`, i.e. three hours. Every workflow that calls `molecule.yml` has a timeout in the 20-120 minute range, so a scenario that failed the memory check would silently retry until the workflow itself was killed. The user got a "The operation was canceled" message with zero context about what actually went wrong. Cutting `retries` to 30 means the task fails loudly after 15 minutes with the last "No capacity: X committed + Y needed > Z available" stdout, well inside the shortest workflow timeout.

Second, Ansible runs unbuffered through Python and GitHub Actions logs are not a TTY, so the `FAILED - RETRYING (N retries left)` messages sit in the stdout buffer and only flush when the buffer fills. On the two hangs I looked at, 73 retry lines all appeared at the same microsecond timestamp after roughly an hour of "silence." `PYTHONUNBUFFERED=1` in the workflow `env:` fixes this so the retry chatter surfaces in real time.

Third, `elasticsearch_roles_calculation` asks for `4 × 4 GB = 16 GB` even though its heap is 1 GB and the scenario only exercises the role-count calculation. Under peak concurrency the 16 GB request never won a slot against the 6-8 GB scenarios that kept flowing in and out. Halving each container to 2 GB drops the ask to 8 GB total, which clears the gate under the same load.

Together the three changes should turn "job cancelled after 45 minutes of silence" into either "runs green" or "fails loudly with a real error" — no more guessing which of the two is happening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility of Python and Ansible retry messages during automated checks.
  * Reduced memory allocation for Elasticsearch calculation and monitoring nodes to help prevent capacity and timeout issues.
  * Adjusted container startup retries to fail faster and align with workflow timeout limits.
  * Extended full-stack validation timeouts and limited concurrent jobs to improve reliability under memory constraints.
  * Improved Elasticsearch upgrade test reliability by coordinating memory usage across concurrent checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->