### PR TITLE
fix(certs): make *_cert_will_expire_soon overridable from playbooks

### DIFF
--- a/roles/beats/defaults/main.yml
+++ b/roles/beats/defaults/main.yml
@@ -223,3 +223,11 @@ beats_tls_ca_content: ""
 
 # @var beats_tls_remote_src:description: Source location for external cert files. false = files on Ansible controller, true = files already on managed node
 beats_tls_remote_src: false
+
+# @var beats_cert_will_expire_soon:description: >
+#   Force renewal of the Beats client certificate on the next run.
+#   Normally flipped to true automatically by the cert_check_expiry task
+#   when the certificate is within `beats_cert_expiration_buffer` days of expiry;
+#   set to true from a playbook to force renewal regardless of buffer.
+# @end
+beats_cert_will_expire_soon: false

--- a/roles/beats/vars/main.yml
+++ b/roles/beats/vars/main.yml
@@ -1,3 +1,1 @@
 ---
-# Internal state — do not set manually
-beats_cert_will_expire_soon: false

--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -243,3 +243,11 @@ elasticsearch_logrotate_rotate: 32
 elasticsearch_logrotate_size: 50M
 # @var elasticsearch_logrotate_maxage:description: Delete rotated files older than this many days
 elasticsearch_logrotate_maxage: 370
+
+# @var elasticsearch_cert_will_expire_soon:description: >
+#   Force renewal of the Elasticsearch node certificate on the next run.
+#   Normally flipped to true automatically by the cert_check_expiry task
+#   when the certificate is within `elasticsearch_cert_expiration_buffer` days of expiry;
+#   set to true from a playbook to force renewal regardless of buffer.
+# @end
+elasticsearch_cert_will_expire_soon: false

--- a/roles/elasticsearch/vars/main.yml
+++ b/roles/elasticsearch/vars/main.yml
@@ -39,9 +39,6 @@ _elasticsearch_managed_keys:
 
 # Internal sentinel values — prevent handler errors on first run.
 # These are overwritten by task register output; users must never set them.
-# Internal state — do not set manually
-elasticsearch_cert_will_expire_soon: false
-
 _elasticsearch_freshstart:
   changed: false
 _elasticsearch_freshstart_security:

--- a/roles/elasticstack/defaults/main.yml
+++ b/roles/elasticstack/defaults/main.yml
@@ -73,3 +73,11 @@ elasticstack_security: true
 
 # @var elasticstack_no_log:description: Suppress sensitive output in Ansible logs. Set to false for debugging
 elasticstack_no_log: true
+
+# @var elasticstack_ca_will_expire_soon:description: >
+#   Force renewal of the CA certificate on the next run.
+#   Normally flipped to true automatically by the cert_check_expiry task
+#   when the certificate is within `elasticstack_ca_expiration_buffer` days of expiry;
+#   set to true from a playbook to force renewal regardless of buffer.
+# @end
+elasticstack_ca_will_expire_soon: false

--- a/roles/elasticstack/vars/main.yml
+++ b/roles/elasticstack/vars/main.yml
@@ -1,3 +1,1 @@
 ---
-# Internal state — do not set manually
-elasticstack_ca_will_expire_soon: false

--- a/roles/kibana/defaults/main.yml
+++ b/roles/kibana/defaults/main.yml
@@ -119,3 +119,11 @@ kibana_sniff_on_connection_fault: false
 #   xpack.reporting.enabled: false
 # @end
 kibana_extra_config: {}
+
+# @var kibana_cert_will_expire_soon:description: >
+#   Force renewal of the Kibana server certificate on the next run.
+#   Normally flipped to true automatically by the cert_check_expiry task
+#   when the certificate is within `kibana_cert_expiration_buffer` days of expiry;
+#   set to true from a playbook to force renewal regardless of buffer.
+# @end
+kibana_cert_will_expire_soon: false

--- a/roles/kibana/vars/main.yml
+++ b/roles/kibana/vars/main.yml
@@ -1,7 +1,4 @@
 ---
-# Internal state — do not set manually
-kibana_cert_will_expire_soon: false
-
 # Internal sentinel values — prevent handler errors on first run.
 # These are overwritten by task register output; users must never set them.
 _kibana_freshstart:

--- a/roles/logstash/defaults/main.yml
+++ b/roles/logstash/defaults/main.yml
@@ -294,3 +294,11 @@ logstash_plugins: []
 logstash_pipeline_unsafe_shutdown: false
 # @var logstash_skip_root_check:description: Skip the Logstash 9.x root user upgrade warning check
 logstash_skip_root_check: false
+
+# @var logstash_cert_will_expire_soon:description: >
+#   Force renewal of the Logstash client certificate on the next run.
+#   Normally flipped to true automatically by the cert_check_expiry task
+#   when the certificate is within `logstash_cert_expiration_buffer` days of expiry;
+#   set to true from a playbook to force renewal regardless of buffer.
+# @end
+logstash_cert_will_expire_soon: false

--- a/roles/logstash/vars/main.yml
+++ b/roles/logstash/vars/main.yml
@@ -1,7 +1,4 @@
 ---
-# Internal state — do not set manually
-logstash_cert_will_expire_soon: false
-
 # Internal sentinel values — prevent handler errors on first run.
 # These are overwritten by task register output; users must never set them.
 _logstash_freshstart:


### PR DESCRIPTION
Closes #157.

The five `*_cert_will_expire_soon` flags — one per role plus the CA one on elasticstack — sat in `vars/main.yml`, which sits above play vars in the Ansible precedence hierarchy. That meant a playbook doing `vars: elasticsearch_cert_will_expire_soon: true` had no effect: as soon as the role was included, the value got reverted to `false` from `vars/main.yml`, and renewal never fired. I ran into this myself writing the cert-renewal molecule scenario for #155 and had to work around it by manipulating `_cert_expiration_buffer` instead.

Moving each flag to `defaults/main.yml` with an `@var` docblock puts them in the precedence tier every other tunable lives in, so play vars, inventory vars, and command-line `-e` all win as expected. Runtime mutation from `cert_check_expiry` still wins on top of both because it goes through `set_fact` (host fact, higher precedence than either).

Documented that these are normally flipped automatically and only need to be set manually to force renewal outside the buffer window. No behaviour change for callers that never set them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documented options to force renewal of Beats, Elasticsearch, Kibana, and Logstash certificates on the next run.
  - Added an option to force Elastic Stack certificate authority renewal.
  - Certificate renewal settings remain disabled by default and can also be activated automatically when certificates approach expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->