### PR TITLE
docs(elasticsearch): cross-ref pre- and post-install upgrade detection

### DIFF
--- a/molecule/elasticsearch_upgrade_8to9_single/converge.yml
+++ b/molecule/elasticsearch_upgrade_8to9_single/converge.yml
@@ -124,15 +124,15 @@
       ansible.builtin.include_role:
         name: oddly.elasticstack.repos
 
-    # The role's elasticstack_version: latest path does NOT trigger the
-    # rolling-upgrade detection on same-major bumps — only pinned-higher
-    # version OR release change qualifies (see
-    # roles/elasticsearch/tasks/elasticsearch-upgrade-detection.yml).
-    # And the chiark apt/yum mirror's cached metadata may not surface
-    # newer 8.x patches without a forced refresh. Drive the package +
-    # restart directly here, as the original test did. Worth a follow-up
-    # to add a "latest-mode same-major upgrade detection" path to the
-    # role, but that's a role change, not a test change.
+    # The role DOES detect same-major latest-mode upgrades post-install
+    # (see roles/elasticsearch/tasks/main.yml "Rolling restart after
+    # package upgrade") — the earlier "not wired up" note here was wrong.
+    # We still drive the package + restart directly in this scenario
+    # because the chiark apt/yum mirror's cached metadata may not surface
+    # newer 8.x patches without a forced refresh, and the test needs a
+    # deterministic bump from 8.10 to the latest 8.x. Refreshing the
+    # cache explicitly gets us that without depending on when the mirror
+    # last pulled.
     - name: Force apt cache update before 8.x upgrade
       ansible.builtin.apt:
         update_cache: true

--- a/roles/elasticsearch/tasks/elasticsearch-upgrade-detection.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-upgrade-detection.yml
@@ -4,13 +4,25 @@
 # minor, or patch — should restart nodes one at a time with shard allocation
 # management rather than restarting all nodes simultaneously.
 #
-# Pre-install detection covers cases where we know the target version:
-# 1. Pinned version higher than installed (elasticstack_version: "9.2.0")
-# 2. Major version change (elasticstack_release differs from installed)
+# There are TWO detection points and this file only handles the first.
 #
-# For "latest" mode, we can't know pre-install whether a newer version is
-# available. The normal package tasks handle installation with state: latest,
-# and if the package changed, a rolling restart is triggered post-install.
+# 1. PRE-install (this file): we know the target version before touching
+#    packages, so we can set _elasticsearch_needs_rolling_upgrade and let
+#    "Update Elasticsearch if needed" run the full rolling path (which
+#    does the package upgrade per-node under shard-allocation management).
+#    Fires when:
+#      a. Pinned version higher than installed (elasticstack_version: "9.2.0")
+#      b. Major version change (elasticstack_release differs from installed)
+#
+# 2. POST-install (see "Detect if package was upgraded (post-install)" and
+#    "Rolling restart after package upgrade" in main.yml): for
+#    elasticstack_version: latest, we can't know pre-install whether a
+#    newer version is available, so the normal package task runs with
+#    state: latest and we look at its .changed field. If it upgraded, a
+#    rolling restart fires post-install.
+#
+# Both paths converge on elasticsearch-rolling-upgrade.yml; only the
+# "when did we know we had to?" differs.
 - name: elasticsearch-upgrade-detection | Detect if rolling upgrade is needed
   ansible.builtin.set_fact:
     _elasticsearch_needs_rolling_upgrade: >-


### PR DESCRIPTION
Closes #156.

The rolling upgrade path has two detection points: pre-install in `elasticsearch-upgrade-detection.yml` (pinned version bump, release change) and post-install in `main.yml` (looks at the package task's `.changed` field, covers `elasticstack_version: latest`). The header comment on the pre-install file only described its own half, so when I hit the "did the upgrade run?" question while writing the `elasticsearch_upgrade_8to9_single` scenario I read that comment, concluded latest-mode was unhandled, filed #156, and moved on. Then I put the same wrong note in the scenario itself.

The code is fine — post-install detection has been there since commit d8ad04e (March 2026). This PR just documents both halves in the header and rewrites the outdated scenario comment. The scenario still drives the package + restart directly, but for the real reason (chiark mirror cache freshness for the deterministic 8.10 → 8.19 bump), not the wrong one.