### PR TITLE
fix(kibana): fail-fast on permanent errors in readiness check

### DIFF
--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -145,8 +145,16 @@
   block:
     - name: Wait for Kibana readiness ({{ 'HTTPS' if kibana_tls | default(false) | bool else 'HTTP' }})
       ansible.builtin.shell:
+        # Exit codes:
+        #   0  ready (200 or 401)
+        #   1  transient — still starting up, keep retrying
+        #   2  permanent — service dead or a fatal log line already surfaced
         cmd: |
           if ! systemctl is-active --quiet kibana; then
+            exit 2
+          fi
+          if journalctl -u kibana --no-pager -n 100 --since '2 minutes ago' 2>/dev/null | \
+              grep -Eq 'FATAL|Unable to connect to Elasticsearch|Authentication.*failed|Kibana server is not ready.*fatal'; then
             exit 2
           fi
           HTTP_CODE=$(curl -sk -o /dev/null -w '%{http_code}' {{ 'https' if kibana_tls | default(false) | bool else 'http' }}://localhost:5601/api/status 2>/dev/null) || true

--- a/roles/kibana/tasks/restart_and_verify_kibana.yml
+++ b/roles/kibana/tasks/restart_and_verify_kibana.yml
@@ -23,7 +23,19 @@
 
     - name: restart_and_verify_kibana | Wait for Kibana readiness ({{ 'HTTPS' if kibana_tls | default(false) | bool else 'HTTP' }})
       ansible.builtin.shell:
+        # Exit codes:
+        #   0  ready (200 or 401)
+        #   1  transient — still starting up, keep retrying
+        #   2  permanent — service died or a fatal log line already surfaced,
+        #      no point in waiting the remaining retries
         cmd: |
+          if ! systemctl is-active --quiet kibana; then
+            exit 2
+          fi
+          if journalctl -u kibana --no-pager -n 100 --since '2 minutes ago' 2>/dev/null | \
+              grep -Eq 'FATAL|Unable to connect to Elasticsearch|Authentication.*failed|Kibana server is not ready.*fatal'; then
+            exit 2
+          fi
           HTTP_CODE=$(curl -sk -o /dev/null -w '%{http_code}' {{ 'https' if kibana_tls | default(false) | bool else 'http' }}://localhost:5601/api/status 2>/dev/null) || true
           if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "401" ]; then
             exit 0
@@ -34,6 +46,7 @@
       retries: 60
       delay: 5
       changed_when: false
+      failed_when: _kibana_http_check.rc == 2
 
   rescue:
     - name: restart_and_verify_kibana | Get recent Kibana journal output
@@ -45,7 +58,7 @@
     - name: restart_and_verify_kibana | Fail with Kibana startup diagnostics
       ansible.builtin.fail:
         msg: |
-          Kibana failed to start.
+          Kibana failed to start{% if _kibana_http_check.rc | default(0) == 2 %} (permanent error detected — see log){% else %} (HTTP did not become ready within 300s){% endif %}.
 
           Recent log output:
           {{ _kibana_journal.stdout }}


### PR DESCRIPTION
Closes #127.

The Kibana readiness probe in `roles/kibana/tasks/main.yml` and `roles/kibana/tasks/restart_and_verify_kibana.yml` was doing a straight 60 × 5 s HTTP wait — five minutes of "still not ready?" regardless of whether the failure was transient or terminal. A wrong `kibana_system` password, an unreachable Elasticsearch, or a startup FATAL all took the full five minutes to surface, which is a lot to wait through for a config typo.

Extend the shell probe with two short-circuits before the HTTP check: if `systemctl is-active` says the unit is dead, exit 2; if `journalctl -u kibana --since 2 minutes ago` shows a `FATAL` line, `Unable to connect to Elasticsearch`, `Authentication.*failed`, or `Kibana server is not ready.*fatal`, also exit 2. `failed_when: rc == 2` drops Ansible straight into the `rescue` block, which prints the journal — same rescue path as before, just reached in seconds instead of minutes.

`main.yml` already had the `systemctl` half; I added the journal grep there and gave `restart_and_verify_kibana.yml` the same treatment (it had neither). Success path is untouched, so no existing scenario regresses.