### PR TITLE
feat(elasticsearch): install logrotate config for /var/log/elasticsearch

### DIFF
--- a/molecule/elasticsearch_default/verify.yml
+++ b/molecule/elasticsearch_default/verify.yml
@@ -124,3 +124,29 @@
         fail_msg: "vm.swappiness is {{ _swappiness.stdout }}, expected 1"
       run_once: true
       when: _swappiness is not skipped
+
+    - name: Verify Elasticsearch logrotate config exists
+      ansible.builtin.stat:
+        path: /etc/logrotate.d/elasticsearch
+      register: _es_logrotate
+
+    - name: Assert Elasticsearch logrotate config is installed
+      ansible.builtin.assert:
+        that:
+          - _es_logrotate.stat.exists
+          - _es_logrotate.stat.mode == '0644'
+        fail_msg: "/etc/logrotate.d/elasticsearch missing or wrong permissions"
+
+    - name: Read logrotate config
+      ansible.builtin.slurp:
+        src: /etc/logrotate.d/elasticsearch
+      register: _es_logrotate_content
+
+    - name: Assert logrotate config sets expected directives
+      ansible.builtin.assert:
+        that:
+          - "'copytruncate' in (_es_logrotate_content.content | b64decode)"
+          - "'daily' in (_es_logrotate_content.content | b64decode)"
+          - "'rotate 32' in (_es_logrotate_content.content | b64decode)"
+          - "'/var/log/elasticsearch/*.log' in (_es_logrotate_content.content | b64decode)"
+        fail_msg: "logrotate config missing expected directives"

--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -228,3 +228,18 @@ elasticsearch_extra_config: {}
 #   elasticsearch.yml (path.repo). Leave empty to disable.
 # @end
 elasticsearch_fs_repo: []
+
+# @var elasticsearch_logrotate_enabled:description: >
+#   Install /etc/logrotate.d/elasticsearch as a safety net for the
+#   /var/log/elasticsearch directory. Uses copytruncate so it does not
+#   conflict with the log4j2 rolling appender's own rotation.
+# @end
+elasticsearch_logrotate_enabled: true
+# @var elasticsearch_logrotate_frequency:description: Rotation cadence (daily, weekly, monthly)
+elasticsearch_logrotate_frequency: daily
+# @var elasticsearch_logrotate_rotate:description: Number of rotated files to keep before deletion
+elasticsearch_logrotate_rotate: 32
+# @var elasticsearch_logrotate_size:description: Rotate when a log file exceeds this size (e.g. 50M, 1G)
+elasticsearch_logrotate_size: 50M
+# @var elasticsearch_logrotate_maxage:description: Delete rotated files older than this many days
+elasticsearch_logrotate_maxage: 370

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -408,6 +408,21 @@
   notify: Restart Elasticsearch
   when: elasticsearch_manage_logging | bool
 
+- name: Install logrotate configuration for Elasticsearch
+  ansible.builtin.template:
+    src: logrotate-elasticsearch.j2
+    dest: /etc/logrotate.d/elasticsearch
+    owner: root
+    group: root
+    mode: "0644"
+  when: elasticsearch_logrotate_enabled | bool
+
+- name: Remove logrotate configuration for Elasticsearch
+  ansible.builtin.file:
+    path: /etc/logrotate.d/elasticsearch
+    state: absent
+  when: not (elasticsearch_logrotate_enabled | bool)
+
 - name: Create Elasticsearch directory
   ansible.builtin.file:
     path: "{{ item.path }}"

--- a/roles/elasticsearch/templates/logrotate-elasticsearch.j2
+++ b/roles/elasticsearch/templates/logrotate-elasticsearch.j2
@@ -1,0 +1,20 @@
+# {{ ansible_managed }}
+# Elasticsearch OS-level logrotate. This is a safety net; log4j2 already
+# rotates the primary appenders when elasticsearch_manage_logging is true,
+# but the /var/log/elasticsearch directory can still accumulate audit,
+# slowlog, and other files over time. copytruncate is used so
+# Elasticsearch does not need to reopen its file descriptors.
+/var/log/elasticsearch/*.log
+/var/log/elasticsearch/*.json
+{
+    {{ elasticsearch_logrotate_frequency }}
+    rotate {{ elasticsearch_logrotate_rotate }}
+    size {{ elasticsearch_logrotate_size }}
+    maxage {{ elasticsearch_logrotate_maxage }}
+    copytruncate
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 0644 elasticsearch {{ elasticsearch_group }}
+}


### PR DESCRIPTION
Closes #61.

Adds `/etc/logrotate.d/elasticsearch` as a safety net for the Elasticsearch log directory. `copytruncate` is used so Elasticsearch does not need to reopen file descriptors, which means the OS rotator coexists with log4j2 rolling appenders rather than fighting them — it mops up files log4j2 does not manage (audit logs, slowlogs, anything users add through `elasticsearch_manage_logging`).

Defaults: on, daily rotation, 32 files kept, 50M size cutoff, 370 day maxage. All tunable through `elasticsearch_logrotate_*` variables. Toggling `elasticsearch_logrotate_enabled: false` removes the file we previously installed, so the flag is fully idempotent in both directions.

Verification in `elasticsearch_default` asserts the file exists, has mode 0644, and includes the expected directives — enough to catch template or task-gating regressions without spinning up an extra molecule scenario.