### PR TITLE
chore(deps): declare ansible-core >=2.19 floor and pin Debian 12 policy

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,5 @@
 ---
-requires_ansible: ">=2.18.0"
+# ansible-core floor: 2.18 went EOL on 2026-05-31, 2.19 goes EOL 2026-11-30.
+# Declare 2.19 as the floor now so 2.18 users see a resolvable error message
+# instead of a stray syntax failure; bump to 2.20 once 2.19 goes EOL.
+requires_ansible: ">=2.19.0"

--- a/molecule/shared/create.yml
+++ b/molecule/shared/create.yml
@@ -46,6 +46,10 @@
     incus_storage_pool: "{{ lookup('env', 'INCUS_STORAGE_POOL') | default('lvm-pool', true) }}"
     # Pre-baked local images with SSH + python3 + authorized_keys ready.
     incus_images:
+      # Debian 12 (Bookworm) went EOL on 2026-07-11. Kept in the full CI
+      # matrix as best-effort while community users still run it; drop
+      # once Trixie hits its 1-year mark (2026-08) and Bookworm images
+      # stop building cleanly.
       debian12: "molecule-debian-12"
       debian13: "molecule-debian-13"
       rockylinux9: "molecule-rockylinux-9"


### PR DESCRIPTION
Closes #116.

The monthly EOL check flagged ansible-core 2.18 (EOL 2026-05-31), ansible-core 2.19 (EOL 2026-11-30), and Debian 12 Bookworm (EOL 2026-07-11). `galaxy.yml` had no `requires_ansible` at all, so 2.18 users hit a stray syntax failure somewhere in the tasks instead of a resolvable "this collection needs 2.19 or newer" up front. Declaring `>=2.19` gives them the readable error. Plan is to bump to `>=2.20` once 2.19 goes EOL in November — noted inline.

For Debian 12: keep it in the full CI matrix as best-effort. Community users are still on Bookworm, nothing in the collection actively breaks on it, and dropping it now with no user complaints is a step ahead of what the ecosystem asks for. Added a comment above the image mapping in `molecule/shared/create.yml` recording the EOL date and the plan to drop once the Bookworm pre-baked image stops building cleanly.

No code path changes; the check_eol workflow keeps running monthly and will re-file if 2.19 catches up to its EOL without a bump landing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented Debian 12’s continued best-effort CI support and planned removal timeline.
  * Updated the minimum supported Ansible version to 2.19.0.
  * Documented the planned future transition to Ansible 2.20 after version 2.19 reaches end of life.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->