### PR TITLE
fix(kibana): set pipefail on the readiness probe

### DIFF
--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -150,6 +150,7 @@
         #   1  transient — still starting up, keep retrying
         #   2  permanent — service dead or a fatal log line already surfaced
         cmd: |
+          set -o pipefail
           if ! systemctl is-active --quiet kibana; then
             exit 2
           fi

--- a/roles/kibana/tasks/restart_and_verify_kibana.yml
+++ b/roles/kibana/tasks/restart_and_verify_kibana.yml
@@ -29,6 +29,7 @@
         #   2  permanent — service died or a fatal log line already surfaced,
         #      no point in waiting the remaining retries
         cmd: |
+          set -o pipefail
           if ! systemctl is-active --quiet kibana; then
             exit 2
           fi


### PR DESCRIPTION
Follow-up to #173. ansible-lint is failing on the `journalctl | grep` pipe I added to the Kibana readiness probe because the shell block does not `set -o pipefail`. Without it, a broken `journalctl` would still let `grep` see an empty pipe and exit 1, so the block would fall through to the HTTP check even on a machine where `journalctl` is truly broken.

Two-line fix: `set -o pipefail` at the top of both readiness probes (main.yml and restart_and_verify_kibana.yml).

Also unblocks #171 and #175, both of which were failing lint on this same violation from main.