### PR TITLE
fix(molecule): add site-local IPv4 SANs to generated test certs

### DIFF
--- a/molecule/shared/generate_test_certs.yml
+++ b/molecule/shared/generate_test_certs.yml
@@ -54,10 +54,17 @@
     path: /tmp/test-certs/server.csr
     privatekey_path: /tmp/test-certs/server.key
     common_name: "{{ ansible_facts.hostname }}"
-    subject_alt_name:
-      - "DNS:{{ ansible_facts.hostname }}"
-      - "DNS:localhost"
-      - "IP:127.0.0.1"
+    # Include every IPv4 the host owns as a SAN. Elasticsearch binds
+    # `network.host: ["_local_", "_site_"]` and its bundled tools
+    # (elasticsearch-setup-passwords, elasticsearch-reset-password) call
+    # https://<publish_host>:9200 — the site-local address, not localhost —
+    # so the cert must accept the container's incusbr0 IP or the TLS
+    # verify fails with "No subject alternative names matching IP
+    # address ..." mid-converge.
+    subject_alt_name: >-
+      {{ ['DNS:' ~ ansible_facts.hostname, 'DNS:localhost', 'IP:127.0.0.1']
+         + (ansible_facts.all_ipv4_addresses | default([])
+            | map('regex_replace', '^', 'IP:') | list) }}
 
 - name: Sign server certificate with CA
   community.crypto.x509_certificate:


### PR DESCRIPTION
The shared test cert used by `elasticsearch_upgrade_8to9_single` and any other scenario that goes through `molecule/shared/generate_test_certs.yml` only listed `DNS:hostname`, `DNS:localhost` and `IP:127.0.0.1`. Elasticsearch binds `network.host: ["_local_", "_site_"]` by default, and its packaged tools (`elasticsearch-setup-passwords` for 8.x, `elasticsearch-reset-password` for 9.x) call `https://<publish_host>:9200` — which resolves to the container's site-local IP on `incusbr0`, not `localhost`. Result: TLS verify fails with `No subject alternative names matching IP address 10.88.0.x found` mid-converge.

That surfaced as `elasticsearch_upgrade_8to9_single` going red on every PR that touched the shared molecule tree — I saw the exact same failure on #155, #169, #170, #171 and #175 without ever tracing it back here. Fixing it makes those PRs actually clean up their tail.

Widen `subject_alt_name` to include every IPv4 the container owns (`ansible_facts.all_ipv4_addresses`). No effect on scenarios that were already passing (they were reaching ES over `localhost` or `127.0.0.1`, both still SANs); it just stops the setup-passwords call over the site address from erroring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server certificates now include the host’s available IPv4 addresses in their subject alternative names.
  * Certificate validation is improved across hostname, localhost, loopback, and dynamically detected network addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->