### PR TITLE
chore(ci): shrink beats_default memory and align test_full_stack distro

### DIFF
--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -99,7 +99,11 @@ jobs:
       # committed memory around 90-100 GB with head-room to spare.
       max-parallel: 6
       matrix:
-        distro: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && fromJSON('["rockylinux9","debian13"]') || (inputs.distros != '' && fromJSON(inputs.distros)) || fromJSON('["rockylinux9","ubuntu2204","ubuntu2404","ubuntu2604","debian12","debian13"]') }}
+        # Standardise on rockylinux10 (not 9) for PR runs to match the rest
+        # of the workflows. Rocky 10 exercises the EL≥9 branch in
+        # roles/repos/tasks/redhat.yml that Rocky 9 already covers, so no
+        # coverage is lost.
+        distro: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && fromJSON('["rockylinux10","debian13"]') || (inputs.distros != '' && fromJSON(inputs.distros)) || fromJSON('["rockylinux9","ubuntu2204","ubuntu2404","ubuntu2604","debian12","debian13"]') }}
         scenario:
           - elasticstack_default
           - es_kibana

--- a/molecule/beats_default/molecule.yml
+++ b/molecule/beats_default/molecule.yml
@@ -11,7 +11,10 @@ platforms:
     groups:
       - elasticsearch
     distro: "${MOLECULE_DISTRO:-debian12}"
-    memory_mb: 4096
+    # Beats-only scenario; no ES deployed even though the platform is in
+    # the `elasticsearch` group (leftover from the shared inventory). 2 GB
+    # is enough for filebeat + metricbeat + auditbeat side-by-side.
+    memory_mb: 2048
 provisioner:
   name: ansible
   env:

--- a/scripts/wait-for-memory.sh
+++ b/scripts/wait-for-memory.sh
@@ -44,7 +44,7 @@ my_resv="$GATE_DIR/r.${runner}"
 # Update this table when a scenario's memory_mb changes.
 declare -A REQ=(
   [beats_advanced]=2048
-  [beats_default]=4096
+  [beats_default]=2048
   [beats_peculiar]=2048
   [beats_security]=8192
   [cert_renewal]=10752


### PR DESCRIPTION
Three unrelated CI-lean tweaks flagged by the coverage audit that all fit in a single one-line PR:

- `beats_default` asks for 4 GB in the memory-capacity gate but the scenario never deploys Elasticsearch — the platform sits in the `elasticsearch` inventory group only as leftover from the shared inventory layout. 2 GB is comfortably enough for filebeat + metricbeat + auditbeat next to each other. Halving the ask frees a full gate slot under peak concurrency without any coverage change.

- `test_full_stack` listed `rockylinux9` in the PR-time distro matrix while every other workflow uses `rockylinux10`. The EL ≥ 9 branch in `roles/repos/tasks/redhat.yml` is the only distro-specific path involved; rocky10 exercises it identically. Standardise.

- Nightly full-distro fan-out is untouched — Rocky 9 still gets tested on cron.