### PR TITLE
test(kibana): add kibana_extras scenario for the four untested toggles

### DIFF
--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -46,3 +46,17 @@ jobs:
       scenarios: '["kibana_default","kibana_custom","kibana_custom_certs"]'
       distros: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && '["rockylinux10","debian13"]' || '["rockylinux9","rockylinux10","ubuntu2204","ubuntu2404","ubuntu2604","debian12","debian13"]' }}
     secrets: inherit
+
+  # kibana_extras exists to cover the four toggles gated on ES 8.x
+  # (sniffOnConnectionFault, sniffInterval, server.protocol, node_max_old_space_size).
+  # It hard-codes elasticstack_release: 8 in converge.yml, so running it
+  # on the ES-9 matrix would duplicate the ES-8 run. One distro on PR is
+  # enough to catch template regressions.
+  molecule_kibana_extras:
+    needs: lint_kibana
+    uses: ./.github/workflows/molecule.yml
+    with:
+      scenarios: '["kibana_extras"]'
+      distros: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && '["debian13"]' || '["debian13","rockylinux10"]' }}
+      releases: '["8"]'
+    secrets: inherit

--- a/molecule/kibana_extras/converge.yml
+++ b/molecule/kibana_extras/converge.yml
@@ -1,0 +1,35 @@
+---
+# Deploy ES 8.x + Kibana with the four toggles nothing else exercises,
+# so the assertions in verify.yml prove the corresponding
+# roles/kibana/templates/kibana.yml.j2 and roles/kibana/tasks/main.yml
+# code paths actually render.
+- name: Converge Kibana extras
+  hosts: all
+  vars:
+    # Pinned to ES 8.x because kibana_sniff_on_connection_fault and
+    # kibana_sniff_interval are gated on `elasticstack_release | int < 9`.
+    elasticstack_release: 8
+    elasticstack_full_stack: true
+    elasticstack_no_log: false
+    elasticsearch_heap: "1"
+
+    # The four toggles under test:
+    kibana_node_max_old_space_size: 2048
+    kibana_server_protocol: "http"
+    kibana_sniff_on_connection_fault: true
+    kibana_sniff_interval: 30000
+
+  tasks:
+    - name: Include Elastic Repos
+      ansible.builtin.include_role:
+        name: oddly.elasticstack.repos
+
+    - name: Deploy Elasticsearch
+      ansible.builtin.include_role:
+        name: oddly.elasticstack.elasticsearch
+      when: "'elasticsearch' in group_names"
+
+    - name: Deploy Kibana
+      ansible.builtin.include_role:
+        name: oddly.elasticstack.kibana
+      when: "'kibana' in group_names"

--- a/molecule/kibana_extras/create.yml
+++ b/molecule/kibana_extras/create.yml
@@ -1,0 +1,1 @@
+../shared/create.yml

--- a/molecule/kibana_extras/destroy.yml
+++ b/molecule/kibana_extras/destroy.yml
@@ -1,0 +1,1 @@
+../shared/destroy.yml

--- a/molecule/kibana_extras/molecule.yml
+++ b/molecule/kibana_extras/molecule.yml
@@ -1,0 +1,39 @@
+---
+# Coverage for the Kibana toggles the other scenarios don't touch:
+#   - kibana_node_max_old_space_size  (systemd node.options rewrite)
+#   - kibana_server_protocol          (server.protocol emitted in kibana.yml)
+#   - kibana_sniff_on_connection_fault + kibana_sniff_interval
+#     (both gated on elasticstack_release | int < 9, so this scenario
+#      hard-codes release=8 rather than relying on the matrix)
+prerun: false
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+driver:
+  name: default
+platforms:
+  - name: "kib-extra-es1-${MOLECULE_DISTRO:-debian12}${MOLECULE_RUN_SUFFIX}"
+    groups:
+      - elasticsearch
+    distro: "${MOLECULE_DISTRO:-debian12}"
+    memory_mb: 4096
+  - name: "kib-extra-kb1-${MOLECULE_DISTRO:-debian12}${MOLECULE_RUN_SUFFIX}"
+    groups:
+      - kibana
+    distro: "${MOLECULE_DISTRO:-debian12}"
+    memory_mb: 2048
+provisioner:
+  name: ansible
+  env:
+    ANSIBLE_LOG_PATH: /var/log/ansible.log
+  connection_options:
+    ansible_connection: ssh
+    ansible_user: root
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no"
+  inventory:
+    group_vars:
+      all:
+        ansible_python_interpreter: /usr/bin/python3
+verifier:
+  name: ansible

--- a/molecule/kibana_extras/prepare.yml
+++ b/molecule/kibana_extras/prepare.yml
@@ -1,0 +1,16 @@
+---
+- name: Prepare
+  hosts: all
+  vars:
+    distro_cache_url: "{{ lookup('env', 'DISTRO_CACHE_URL') }}"
+  tasks:
+    - name: Populate /etc/hosts with molecule instances
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        regexp: ".*{{ item }}$"
+        line: "{{ hostvars[item]['ansible_host'] }} {{ item }}"
+      loop: "{{ groups['all'] }}"
+      when: groups['all'] | length > 1
+
+    - name: Common prepare tasks
+      ansible.builtin.include_tasks: ../shared/prepare_common.yml

--- a/molecule/kibana_extras/requirements.yml
+++ b/molecule/kibana_extras/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - community.general

--- a/molecule/kibana_extras/verify.yml
+++ b/molecule/kibana_extras/verify.yml
@@ -1,0 +1,56 @@
+---
+- name: Verify Kibana extras
+  hosts: all
+  tasks:
+    - name: Run Kibana-side assertions
+      when: "'kibana' in group_names"
+      block:
+        - name: Read kibana.yml
+          ansible.builtin.slurp:
+            src: /etc/kibana/kibana.yml
+          register: kibana_yml
+
+        - name: Assert server.protocol is emitted
+          ansible.builtin.assert:
+            that:
+              - "'server.protocol: \"http\"' in (kibana_yml.content | b64decode)"
+            fail_msg: >-
+              server.protocol not emitted; kibana_server_protocol branch in
+              kibana.yml.j2 did not render.
+
+        - name: Assert elasticsearch.sniffOnConnectionFault fired
+          ansible.builtin.assert:
+            that:
+              - "'elasticsearch.sniffOnConnectionFault: true' in (kibana_yml.content | b64decode)"
+            fail_msg: >-
+              sniffOnConnectionFault not rendered; the < 9 gate on
+              kibana_sniff_on_connection_fault may have flipped without
+              this scenario noticing.
+
+        - name: Assert elasticsearch.sniffInterval fired
+          ansible.builtin.assert:
+            that:
+              - "'elasticsearch.sniffInterval: 30000' in (kibana_yml.content | b64decode)"
+            fail_msg: >-
+              sniffInterval not rendered; the < 9 gate on
+              kibana_sniff_interval may have flipped.
+
+        - name: Read node.options for max-old-space-size
+          ansible.builtin.slurp:
+            src: /etc/kibana/node.options
+          register: kibana_node_opts
+
+        - name: Assert --max-old-space-size was set from the variable
+          ansible.builtin.assert:
+            that:
+              - "'--max-old-space-size=2048' in (kibana_node_opts.content | b64decode)"
+            fail_msg: >-
+              --max-old-space-size line missing from /etc/kibana/node.options;
+              the kibana_node_max_old_space_size lineinfile task in
+              roles/kibana/tasks/main.yml did not fire.
+
+        - name: Verify kibana.yml is still valid YAML
+          ansible.builtin.assert:
+            that:
+              - "(kibana_yml.content | b64decode | from_yaml) is mapping"
+            fail_msg: "kibana.yml is not parseable as YAML after the extras were applied"

--- a/scripts/wait-for-memory.sh
+++ b/scripts/wait-for-memory.sh
@@ -64,6 +64,7 @@ declare -A REQ=(
   [kibana_custom]=8192
   [kibana_custom_certs]=8192
   [kibana_default]=4096
+  [kibana_extras]=6144
   [logstash_advanced]=2048
   [logstash_centralized_pipelines]=2048
   [logstash_custom_pipeline]=2048


### PR DESCRIPTION
Closes the concrete coverage gaps flagged by the CI audit — four user-facing Kibana toggles that no molecule scenario currently exercises:

- `kibana_node_max_old_space_size` — the systemd node.options lineinfile task in `roles/kibana/tasks/main.yml:118` never fired in any scenario. Regressions in that task would ship silently.
- `kibana_server_protocol` — the `{% if %}` branches at `kibana.yml.j2:5` (renders `server.protocol`) and `:49` (adds it to the managed-keys filter for `kibana_extra_config` dedupe).
- `kibana_sniff_on_connection_fault` and `kibana_sniff_interval` — both gated on `elasticstack_release | int < 9`. `kibana_custom` sets `kibana_sniff_on_start` but not these two, and the matrix defaults to release 9, so both branches went untested despite being in the docs.

`molecule/kibana_extras/` is a 2-node scenario (ES 4 GB + Kibana 2 GB) that pins `elasticstack_release: 8` in converge.yml so the `< 9` gate fires deterministically. Verify slurps `kibana.yml` and `node.options` and asserts each expected line is present.

Wired into `test_role_kibana.yml` as its own job (`releases: ["8"]`, one distro on PR, two on cron) rather than inflating the existing `molecule_kibana` matrix — the whole point is exercising the ES-8-only branch. Also added an entry in `scripts/wait-for-memory.sh` so the memory-gate reserves the right size.