### PR TITLE
chore(ci): drop ES 8 from PR-time matrix on non-ES workflows

### DIFF
--- a/.github/workflows/test_full_stack.yml
+++ b/.github/workflows/test_full_stack.yml
@@ -105,9 +105,10 @@ jobs:
           - es_kibana
           - logstash_elasticsearch
           - cert_renewal
-        release:
-          - 8
-          - 9
+        # PR/merge_group: 9 only — the full-stack matrix is 100+ min per job
+        # and the biggest source of CI queue pressure. Cron and workflow_dispatch
+        # keep both releases. ES 8.19 EOL 2027-07-15.
+        release: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && fromJSON('[9]') || fromJSON('[8,9]') }}
         # Rocky 10 excluded: EPEL 10 does not ship Redis yet.
         # Rocky 10 is still tested via the ES modules workflow.
 

--- a/.github/workflows/test_role_beats.yml
+++ b/.github/workflows/test_role_beats.yml
@@ -44,5 +44,7 @@ jobs:
     uses: ./.github/workflows/molecule.yml
     with:
       scenarios: '["beats_default","beats_peculiar","beats_advanced","beats_security"]'
+      # PR: 9 only. Cron keeps ["8","9"] until ES 8.19 EOL 2027-07-15.
+      releases: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && '["9"]' || '["8","9"]' }}
       distros: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && '["rockylinux10","debian13"]' || '["rockylinux9","rockylinux10","ubuntu2204","ubuntu2404","ubuntu2604","debian12","debian13"]' }}
     secrets: inherit

--- a/.github/workflows/test_role_kibana.yml
+++ b/.github/workflows/test_role_kibana.yml
@@ -45,6 +45,11 @@ jobs:
     with:
       scenarios: '["kibana_default","kibana_custom","kibana_custom_certs"]'
       distros: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && '["rockylinux10","debian13"]' || '["rockylinux9","rockylinux10","ubuntu2204","ubuntu2404","ubuntu2604","debian12","debian13"]' }}
+      # ES 8.19 gets support until 2027-07-15. PR runs test 9 only to halve
+      # the matrix; nightly/schedule keeps the full ["8","9"] fan-out — and
+      # the dedicated kibana_extras job below always runs on 8. That leaves
+      # no ES-8 Kibana path untested in the aggregate weekly picture.
+      releases: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && '["9"]' || '["8","9"]' }}
     secrets: inherit
 
   # kibana_extras exists to cover the four toggles gated on ES 8.x

--- a/.github/workflows/test_role_logstash.yml
+++ b/.github/workflows/test_role_logstash.yml
@@ -45,4 +45,8 @@ jobs:
     with:
       scenarios: '["logstash_default","logstash_ssl","logstash_custom_pipeline","logstash_advanced","logstash_external_certs","logstash_standalone_certs","logstash_centralized_pipelines"]'
       distros: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && '["rockylinux10","debian13"]' || '["rockylinux9","rockylinux10","ubuntu2204","ubuntu2404","ubuntu2604","debian12","debian13"]' }}
+      # PR: 9 only. Cron/schedule keeps ["8","9"] — Logstash config differs
+      # meaningfully between majors (api.http.* vs http.* etc.), so we still
+      # want ES 8.19 covered before its 2027-07-15 EOL.
+      releases: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && '["9"]' || '["8","9"]' }}
     secrets: inherit

--- a/.github/workflows/test_role_repos.yml
+++ b/.github/workflows/test_role_repos.yml
@@ -44,6 +44,10 @@ jobs:
     uses: ./.github/workflows/molecule.yml
     with:
       scenarios: '["repos_default"]'
+      # PR: 9 only. Cron keeps ["8","9"] — the repos role has separate
+      # elastic-8.x / elastic-9.x repo blocks and both stay tested nightly
+      # until ES 8.19 EOL 2027-07-15.
+      releases: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && '["9"]' || '["8","9"]' }}
       distros: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && '["rockylinux10","debian13"]' || '["rockylinux9","rockylinux10","ubuntu2204","ubuntu2404","ubuntu2604","debian12","debian13"]' }}
       timeout: 30
     secrets: inherit


### PR DESCRIPTION
Follow-up on the CI audit. ES 8.19 gets Elastic support until 2027-07-15, so we keep ES 8 tested on cron/schedule and on the ES-specific workflows — the change is only that PR and `merge_group` events now run release 9 alone on the workflows where the ES-version fan-out barely differentiates:

- `test_role_kibana` — the new `kibana_extras` job in #179 is already ES 8 by construction, so the Kibana < 9 branches (sniffOnConnectionFault, sniffInterval) still fire every PR run.
- `test_role_logstash` — Logstash config differs between majors (api.http vs http, `xpack.monitoring.enabled`, `pipeline.buffer.type`), so ES 8 stays on cron.
- `test_role_beats` — Beats is largely version-agnostic; nothing lost by moving 8 to cron.
- `test_role_repos` — the `elastic-8.x` / `elastic-9.x` repo blocks are still exercised nightly.
- `test_full_stack` — 100+ min per job, biggest queue drain by a mile.

Untouched: `test_role_elasticsearch` (ES-focused), `test_elasticsearch_upgrade` (literally the 8→9 path), `test_elasticsearch_modules` (release-specific).

Net effect: PR-time molecule matrix roughly halves on the affected workflows, every meaningful ES 8 code path still runs at least nightly, and full ES 8 coverage stays until we hit 2027-07-15.