### PR TITLE
fix(molecule): use http1 for kibana_server_protocol in kibana_extras

### DIFF
--- a/molecule/kibana_extras/converge.yml
+++ b/molecule/kibana_extras/converge.yml
@@ -15,7 +15,10 @@
 
     # The four toggles under test:
     kibana_node_max_old_space_size: 2048
-    kibana_server_protocol: "http"
+    # Kibana only accepts "http1" or "http2" for server.protocol; anything
+    # else is rejected at config validation. We use http1 because http2
+    # requires TLS on the server side and this scenario runs plain HTTP.
+    kibana_server_protocol: "http1"
     kibana_sniff_on_connection_fault: true
     kibana_sniff_interval: 30000
 

--- a/molecule/kibana_extras/verify.yml
+++ b/molecule/kibana_extras/verify.yml
@@ -13,7 +13,7 @@
         - name: Assert server.protocol is emitted
           ansible.builtin.assert:
             that:
-              - "'server.protocol: \"http\"' in (kibana_yml.content | b64decode)"
+              - "'server.protocol: \"http1\"' in (kibana_yml.content | b64decode)"
             fail_msg: >-
               server.protocol not emitted; kibana_server_protocol branch in
               kibana.yml.j2 did not render.


### PR DESCRIPTION
Follow-up to #179. The new `kibana_extras` scenario failed on its first cross-PR run (visible on #180) because I set `kibana_server_protocol: "http"`. Kibana only accepts `http1` or `http2` on `server.protocol` — anything else is rejected at config validation with `expected value to equal [http1]/[http2]`, and Kibana crashes on start.

`http1` is the right value here — the scenario runs plain HTTP, and `http2` needs TLS on the listener. Verify assertion moves with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Kibana protocol configuration to use the supported `http1` value.
  * Clarified that HTTP/2 requires TLS.
  * Updated verification checks to reflect the corrected protocol setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->