### PR TITLE
test: fill CI gaps from PRs #171 and #173

### DIFF
--- a/molecule/cert_renewal/converge.yml
+++ b/molecule/cert_renewal/converge.yml
@@ -114,19 +114,18 @@
     logstash_heap: "512m"
     logstash_pipeline_unsafe_shutdown: true
     kibana_tls: true
-    # Force certificate renewal.
-    #
-    # The *_cert_will_expire_soon flags live in each role's vars/main.yml
-    # (precedence higher than play vars), so setting them here would be
-    # overridden when the role loads. Instead set the expiration buffer to
-    # a value larger than the cert's validity period — the role's
-    # cert_check_expiry task then computes "expires within buffer days" as
-    # true and flips the will_expire_soon fact via set_fact, which DOES
-    # propagate correctly to the renewal gates.
-    elasticstack_ca_expiration_buffer: 99999
-    elasticsearch_cert_expiration_buffer: 99999
-    kibana_cert_expiration_buffer: 99999
-    logstash_cert_expiration_buffer: 99999
+    # Force certificate renewal by setting the *_cert_will_expire_soon
+    # flags directly from play vars. These now live in each role's
+    # defaults/main.yml (moved there in #171), so play vars override them
+    # cleanly and the role's renewal gates trip immediately without
+    # cert_check_expiry having to compute an expiration date first.
+    # (Setting *_cert_expiration_buffer to a big number also works and
+    # is what this scenario used before #171 landed; both paths are
+    # supported, this one is the intended API.)
+    elasticstack_ca_will_expire_soon: true
+    elasticsearch_cert_will_expire_soon: true
+    kibana_cert_will_expire_soon: true
+    logstash_cert_will_expire_soon: true
     logstash_cert_force_regenerate: true
   tasks:
     - name: Reset shared role import guard for re-run

--- a/molecule/kibana_extras/verify.yml
+++ b/molecule/kibana_extras/verify.yml
@@ -54,3 +54,50 @@
             that:
               - "(kibana_yml.content | b64decode | from_yaml) is mapping"
             fail_msg: "kibana.yml is not parseable as YAML after the extras were applied"
+
+        # Coverage for #173's fail-fast rescue branch. The role's readiness
+        # probe was patched to short-circuit with rc=2 when `systemctl
+        # is-active` reports the unit as dead. Stop Kibana, run the
+        # readiness script inline, and assert rc=2 — no existing scenario
+        # deliberately breaks Kibana so this whole code path was cold.
+        - name: Stop Kibana to trigger the permanent-error branch
+          ansible.builtin.service:
+            name: kibana
+            state: stopped
+
+        - name: Re-run the readiness probe against a stopped Kibana
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              if ! systemctl is-active --quiet kibana; then
+                exit 2
+              fi
+              if journalctl -u kibana --no-pager -n 100 --since '2 minutes ago' 2>/dev/null | \
+                  grep -Eq 'FATAL|Unable to connect to Elasticsearch|Authentication.*failed|Kibana server is not ready.*fatal'; then
+                exit 2
+              fi
+              HTTP_CODE=$(curl -sk -o /dev/null -w '%{http_code}' http://localhost:5601/api/status 2>/dev/null) || true
+              if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "401" ]; then
+                exit 0
+              fi
+              exit 1
+          register: _dead_probe
+          failed_when: false
+          changed_when: false
+
+        - name: Assert the probe returned rc=2 (permanent, not 1 = transient)
+          ansible.builtin.assert:
+            that:
+              - _dead_probe.rc == 2
+            fail_msg: >-
+              Kibana readiness probe returned rc={{ _dead_probe.rc }} against
+              a stopped service; expected rc=2 so the role's rescue block
+              fails fast with 'Kibana service died' instead of waiting out
+              the 5-minute retry loop.
+
+        # Start Kibana again so the follow-up idempotence run sees it as
+        # already-started and Start Kibana reports changed=false.
+        - name: Restart Kibana so idempotence sees no change
+          ansible.builtin.service:
+            name: kibana
+            state: started


### PR DESCRIPTION
Post-merge audit flagged three coverage gaps; two of them are safe, small test extensions that landed here. The third — a whole-role check-mode re-include intended to cover #154's guards — turned out to reveal a separate check-mode bug in `elasticsearch-cluster-settings.yml` (references `.json` on a URI response that skips in check mode). Adding the missing guard there is a role fix, not a test, so it stays as a follow-up.

**#171 — direct `*_cert_will_expire_soon` overriding.** `cert_renewal` was written before #171 moved the flags from `vars/main.yml` to `defaults/main.yml`, so it used the `*_cert_expiration_buffer: 99999` trick and the documented `will_expire_soon: true` path stayed unused. Switch the scenario to the intended API. Buffer path still works — the comment now documents both.

**#173 — Kibana fail-fast readiness probe.** No scenario deliberately breaks Kibana, so the `rc=2` shortcut and the `Kibana service died` rescue message were both cold. `kibana_extras` now stops Kibana, re-runs the exact probe script inline, and asserts `rc == 2`. Also restarts Kibana at end of verify so the follow-up idempotence run sees `Start Kibana` as unchanged.

Follow-up: the #154 check-mode coverage will need a role change first (`when: not ansible_check_mode` on `elasticsearch-cluster-settings.yml` line 30, or restructure the block so the `_current` computation only runs when the URI call actually returned data).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate renewal handling when certificates are approaching expiration, including shared and service-specific certificates.
  * Improved Kibana readiness behavior by correctly identifying stopped services as unavailable and restoring service operation afterward.

* **Tests**
  * Expanded automated coverage for certificate renewal scenarios and Kibana service readiness checks.
  * Added validation to support reliable follow-up and idempotence checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->