### PR TITLE
fix(elasticsearch): wait for green before taking the next node down during a rolling upgrade

### DIFF
--- a/docs/reference/elasticsearch.md
+++ b/docs/reference/elasticsearch.md
@@ -449,6 +449,16 @@ elasticsearch_unsafe_upgrade_restart: false
 
 `elasticsearch_unsafe_upgrade_restart` skips rolling upgrade safety checks (shard allocation disable, synced flush, green health wait) and restarts all nodes simultaneously. This loses data availability during the upgrade window. Only use in non-production environments where you trade safety for speed.
 
+```yaml
+elasticsearch_upgrade_wait_status: green
+elasticsearch_upgrade_health_retries: 100
+elasticsearch_upgrade_health_delay: 30
+```
+
+`elasticsearch_upgrade_wait_status` is the minimum cluster health colour the role waits for before it takes the next node down. `green` means the replicas of the previously upgraded node are back before another node is stopped. Set to `yellow` only if you accept that shards may briefly hold a single copy during the upgrade.
+
+`elasticsearch_upgrade_health_retries` and `elasticsearch_upgrade_health_delay` control how long that barrier waits. Defaults give ~50 minutes per node, which covers replica recovery on large data nodes.
+
 ### Internal Variables
 
 These are used internally by the role. Do not set them in your inventory.

--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -92,6 +92,12 @@ elasticsearch_config_restart_health_delay: 30
 elasticsearch_config_restart_node_retries: 200
 # @var elasticsearch_config_restart_node_delay:description: Delay in seconds between restarted node join checks
 elasticsearch_config_restart_node_delay: 3
+# @var elasticsearch_upgrade_wait_status:description: Minimum cluster health status before each node is taken down during a rolling upgrade. Use yellow or green
+elasticsearch_upgrade_wait_status: green
+# @var elasticsearch_upgrade_health_retries:description: Number of cluster health polling attempts before taking a node down during a rolling upgrade
+elasticsearch_upgrade_health_retries: 100
+# @var elasticsearch_upgrade_health_delay:description: Delay in seconds between cluster health polling attempts during a rolling upgrade
+elasticsearch_upgrade_health_delay: 30
 
 # @var elasticsearch_jvm_custom_parameters:description: Additional JVM parameters appended to jvm.options.d. Use for GC tuning, debug flags, etc
 # @var elasticsearch_jvm_custom_parameters:example: >

--- a/roles/elasticsearch/meta/argument_specs.yml
+++ b/roles/elasticsearch/meta/argument_specs.yml
@@ -152,6 +152,21 @@ argument_specs:
         description: Delay in seconds between restarted node join checks
         type: int
         default: 3
+      elasticsearch_upgrade_wait_status:
+        description: Minimum cluster health status before each node is taken down during a rolling upgrade. Use yellow or green.
+        type: str
+        default: green
+        choices:
+          - green
+          - yellow
+      elasticsearch_upgrade_health_retries:
+        description: Number of cluster health polling attempts before taking a node down during a rolling upgrade
+        type: int
+        default: 100
+      elasticsearch_upgrade_health_delay:
+        description: Delay in seconds between cluster health polling attempts during a rolling upgrade
+        type: int
+        default: 30
       elasticsearch_jvm_custom_parameters:
         description: Additional JVM parameters appended to jvm.options.d. Use for GC tuning, debug flags, etc
         type: str

--- a/roles/elasticsearch/tasks/elasticsearch-rolling-upgrade.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-rolling-upgrade.yml
@@ -12,6 +12,17 @@
 # For now we support upgrade only for clusters with security enabled
 # If you positively need support for safely upgrading clusters without security,
 # feel free to open an issue at https://github.com/Oddly/ansible-collection-elasticstack/issues
+# A typo here silently degraded the gate to ['green', 'yellow'] before the
+# ternary got tightened — reject early with a clear message so the operator
+# can spot 'Green'/'red' before any node comes down.
+- name: elasticsearch-rolling-upgrade | Validate elasticsearch_upgrade_wait_status
+  ansible.builtin.assert:
+    that:
+      - elasticsearch_upgrade_wait_status in ['green', 'yellow']
+    fail_msg: >-
+      elasticsearch_upgrade_wait_status must be 'green' or 'yellow',
+      got '{{ elasticsearch_upgrade_wait_status }}'.
+
 - name: elasticsearch-rolling-upgrade | Set connection protocol to https
   ansible.builtin.set_fact:
     elasticsearch_http_protocol: "https"
@@ -132,7 +143,9 @@
 
       # this step is key!!!  Don't restart more nodes
       # until all shards have completed recovery
-    - name: elasticsearch-rolling-upgrade | Wait for cluster health to return to green
+    # Barrier before this node goes down: the previous node's replicas must be
+    # back, otherwise shards are left with a single copy while we stop another node.
+    - name: elasticsearch-rolling-upgrade | Wait for cluster health before taking this node down
       ansible.builtin.uri:
         url: "{{ elasticsearch_http_protocol }}://{{ elasticsearch_api_host }}:{{ elasticstack_elasticsearch_http_port }}/_cluster/health"
         method: GET
@@ -141,9 +154,11 @@
         validate_certs: "{{ elasticsearch_validate_api_certs }}"
         force_basic_auth: true
       register: elasticsearch_response
-      until: ((elasticsearch_response.json | default({})).status | default('')) in ['green', 'yellow']
-      retries: 50
-      delay: 30
+      until: ((elasticsearch_response.json | default({})).status | default('')) in _elasticsearch_upgrade_health_statuses
+      retries: "{{ elasticsearch_upgrade_health_retries | int }}"
+      delay: "{{ elasticsearch_upgrade_health_delay | int }}"
+      vars:
+        _elasticsearch_upgrade_health_statuses: "{{ ['green'] if elasticsearch_upgrade_wait_status == 'green' else ['green', 'yellow'] }}"
       no_log: "{{ elasticstack_no_log }}"
       changed_when: false
       when: _elasticsearch_cluster_reachable | bool
@@ -300,9 +315,13 @@
         validate_certs: "{{ elasticsearch_validate_api_certs }}"
         force_basic_auth: true
       register: elasticsearch_response
-      until: ((elasticsearch_response.json | default({})).status | default('')) in ['green', 'yellow']
+      until: ((elasticsearch_response.json | default({})).status | default('')) in _elasticsearch_upgrade_health_statuses
       retries: 30
       delay: 30
+      vars:
+        # Same gate as the pre-node-down health wait so both sides of the
+        # rolling loop honour the same operator preference.
+        _elasticsearch_upgrade_health_statuses: "{{ ['green'] if elasticsearch_upgrade_wait_status == 'green' else ['green', 'yellow'] }}"
       no_log: "{{ elasticstack_no_log }}"
       changed_when: false
 

--- a/tests/integration/elasticsearch_upgrade_detection_contract.yml
+++ b/tests/integration/elasticsearch_upgrade_detection_contract.yml
@@ -106,3 +106,31 @@
           ansible.builtin.assert:
             that:
               - ansible_failed_result.msg is search('Elasticsearch 9.x requires 8.19.x first')
+
+    # The pre-node-down gate used to hard-code ['green', 'yellow'], so the
+    # next node in the rolling upgrade could come down before the previous
+    # node's replicas were fully recovered.
+    - name: Health gate before taking a node down honours elasticsearch_upgrade_wait_status
+      vars:
+        _gate_file: ../../roles/elasticsearch/tasks/elasticsearch-rolling-upgrade.yml
+      block:
+        - name: Read the rolling upgrade tasks
+          ansible.builtin.set_fact:
+            _gate_src: "{{ lookup('ansible.builtin.file', _gate_file) }}"
+
+        - name: Assert the pre-node gate is driven by the variable
+          ansible.builtin.assert:
+            that:
+              - _gate_src is search('_elasticsearch_upgrade_health_statuses')
+              - _gate_src is search('elasticsearch_upgrade_wait_status')
+            fail_msg: >-
+              The health gate before node shutdown no longer honours
+              elasticsearch_upgrade_wait_status.
+
+        - name: Assert the default demands green
+          ansible.builtin.assert:
+            that:
+              - _defaults.elasticsearch_upgrade_wait_status == 'green'
+            fail_msg: elasticsearch_upgrade_wait_status default must be green.
+          vars:
+            _defaults: "{{ lookup('ansible.builtin.file', '../../roles/elasticsearch/defaults/main.yml') | from_yaml }}"


### PR DESCRIPTION
The pre-shutdown health gate in `elasticsearch-rolling-upgrade.yml` was named "Wait for cluster health to return to green" but accepted `['green', 'yellow']`. After each upgraded node the cluster is yellow while replicas rebuild, so the gate always passed immediately and the next node went down while shards still had a single copy. On a 7-node production cluster this produced a red cluster twice in one evening; with the fix in place the remaining five nodes upgraded without incident.

The gate is now driven by `elasticsearch_upgrade_wait_status` (default `green`, set `yellow` to opt into the old behaviour) with `elasticsearch_upgrade_health_retries`/`_delay` (defaults give ~50 minutes, covering replica recovery on large data nodes).

Covered in `tests/integration/elasticsearch_upgrade_detection_contract.yml`; fails without the fix.