### PR TITLE
refactor(elasticsearch): replace no-op loop-over-group in upgrade includes with a membership guard

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -304,11 +304,12 @@
         force: true
       when: elasticsearch_jvm_custom_parameters is defined and (elasticsearch_jvm_custom_parameters | string | length > 0)
 
+# Membership guard replaces the old loop-over-the-group construct, which only
+# ever matched the host itself and skipped every other iteration.
 - name: Update Elasticsearch if needed
   ansible.builtin.include_tasks: elasticsearch-rolling-upgrade.yml
-  loop: "{{ groups[elasticstack_elasticsearch_group_name] }}"
   when:
-    - "hostvars[item].inventory_hostname == inventory_hostname"
+    - inventory_hostname in groups[elasticstack_elasticsearch_group_name] | default([])
     - _elasticsearch_needs_rolling_upgrade | bool
     - elasticstack_password.stdout is defined
 
@@ -368,9 +369,8 @@
 
 - name: Rolling restart after package upgrade
   ansible.builtin.include_tasks: elasticsearch-rolling-upgrade.yml
-  loop: "{{ groups[elasticstack_elasticsearch_group_name] }}"
   when:
-    - "hostvars[item].inventory_hostname == inventory_hostname"
+    - inventory_hostname in groups[elasticstack_elasticsearch_group_name] | default([])
     - not (_elasticsearch_needs_rolling_upgrade | bool)
     - _elasticsearch_package_upgraded | default(false) | bool
     - elasticstack_password.stdout is defined


### PR DESCRIPTION
Both rolling-upgrade includes in `main.yml` looped over the whole elasticsearch group with `hostvars[item].inventory_hostname == inventory_hostname`, which only ever matches the host itself: the loop ran the include at most once and produced one skip line per other group member per host (98 skip lines on a 7-node cluster), suggesting per-group behaviour that doesn't exist.

The loop did double as an accidental group-membership check (a loop over an empty/absent group skips the task), so the replacement keeps that explicitly: `inventory_hostname in groups[...] | default([])`. The `default([])` also removes an undefined-variable failure when the group is absent, which the old construct would have hit.

Covered in `tests/integration/elasticsearch_upgrade_detection_contract.yml`; fails if either the loop returns or the membership guard is dropped.