### PR TITLE
fix(collection): drop computed defaults from argument specs

### DIFF
--- a/roles/elasticsearch/defaults/main.yml
+++ b/roles/elasticsearch/defaults/main.yml
@@ -59,7 +59,9 @@ elasticsearch_logpath: /var/log/elasticsearch
 # @var elasticsearch_create_logpath:description: Create the log directory if it does not exist
 elasticsearch_create_logpath: false
 # @var elasticsearch_heap:description: JVM heap size in GB. Auto-calculated as half of system RAM, capped at 30GB, minimum 1GB
-elasticsearch_heap: "{{ [[(ansible_facts.memtotal_mb // 1024) // 2, 30] | min, 1] | max }}"
+# The default(0) keeps arg-spec validation working when facts are absent (tag-limited
+# runs with a warm fact cache); a real converge always has facts before this is used.
+elasticsearch_heap: "{{ [[((ansible_facts.memtotal_mb | default(0)) // 1024) // 2, 30] | min, 1] | max }}"
 # @var elasticsearch_pamlimits:description: Configure PAM limits for the elasticsearch user (open files, max processes)
 elasticsearch_pamlimits: true
 # @var elasticsearch_os_tuning:description: >

--- a/roles/elasticsearch/meta/argument_specs.yml
+++ b/roles/elasticsearch/meta/argument_specs.yml
@@ -91,9 +91,9 @@ argument_specs:
         type: bool
         default: false
       elasticsearch_heap:
-        description: JVM heap size in GB. Auto-calculated as half of system RAM, capped at 30GB, minimum 1GB
+        description: JVM heap size in GB. Auto-calculated by the role default as half of system RAM, capped at 30GB, minimum 1GB.
+          No default here on purpose; computing it needs gathered facts, which a spec validation must not rely on.
         type: str
-        default: '{{ [[(ansible_facts.memtotal_mb // 1024) // 2, 30] | min, 1] | max }}'
       elasticsearch_pamlimits:
         description: Configure PAM limits for the elasticsearch user (open files, max processes)
         type: bool

--- a/roles/kibana/defaults/main.yml
+++ b/roles/kibana/defaults/main.yml
@@ -12,7 +12,7 @@
 #   externally reachable URL (e.g. the reverse proxy / VIP) when Kibana runs behind
 #   a proxy, so generated absolute URLs (reporting, share links) are correct.
 # @end
-kibana_public_base_url: "http{% if kibana_tls | bool %}s{% endif %}://{{ elasticstack_kibana_host | default(ansible_facts.fqdn) }}:{{ elasticstack_kibana_port }}"
+kibana_public_base_url: "http{% if kibana_tls | bool %}s{% endif %}://{{ elasticstack_kibana_host | default(ansible_facts.fqdn | default(inventory_hostname)) }}:{{ elasticstack_kibana_port }}"
 
 # === Node.js Memory ===
 

--- a/roles/kibana/meta/argument_specs.yml
+++ b/roles/kibana/meta/argument_specs.yml
@@ -10,8 +10,6 @@ argument_specs:
           (e.g. the reverse proxy / VIP) when Kibana runs behind a proxy, so generated absolute URLs (reporting, share links)
           are correct.
         type: str
-        default: http{% if kibana_tls | bool %}s{% endif %}://{{ elasticstack_kibana_host | default(ansible_facts.fqdn) }}:{{
-          elasticstack_kibana_port }}
       kibana_node_max_old_space_size:
         description: Max V8 old-space heap in MB (maps to --max-old-space-size in node.options). When set, the existing node.options
           line is uncommented/updated. When empty, the package default is left in place.


### PR DESCRIPTION
Two argument-spec options carried templated defaults that reference gathered facts or another role's vars (`elasticsearch_heap` from `ansible_facts.memtotal_mb`, `kibana_server_publicbaseurl` from `elasticstack_kibana_host`/`ansible_facts.fqdn`). Spec defaults are evaluated at validation time even when the option is not supplied, and the validation task is tagged `always` — so any tag-limited run where fact gathering is skipped (smart gathering with a warm cache) fails with `object of type 'dict' has no attribute 'memtotal_mb'` before a single real task runs. Hit in production on a `--tags` run the day after #184 landed.

The real defaults live in `defaults/main.yml` and are unaffected; the spec entries keep their descriptions and lose only the computed `default:`.