### PR TITLE
chore(ci): give the incus-ci memory gate 45 min of patience

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -17,7 +17,7 @@ on:
         description: JSON array of Elastic major versions
       timeout:
         type: number
-        default: 45
+        default: 60
       max-parallel:
         type: number
         default: 10

--- a/molecule/shared/create.yml
+++ b/molecule/shared/create.yml
@@ -130,14 +130,16 @@
         REMOTE_SCRIPT
       changed_when: true
       register: _launch_result
-      # 30 retries × 30s = 15 min. Deliberately shorter than the workflow
-      # timeout (45 min for the standard molecule.yml call, 120 min for
+      # 90 retries × 30s = 45 min. Deliberately shorter than the workflow
+      # timeout (60 min for the standard molecule.yml call, 180 min for
       # full_stack) so the task fails loudly with the last "No capacity:
       # …" stdout instead of being silently cancelled by the workflow
       # timeout — that made the queue-starvation cases very hard to
       # diagnose (see PR investigating the elasticsearch_roles_calculation
-      # / elasticstack_default post-outage hangs).
-      retries: 30
+      # / elasticstack_default post-outage hangs). Bumped from 30 after a
+      # sustained multi-PR CI storm evicted every heavy scenario on the
+      # first attempt.
+      retries: 90
       delay: 30
       until: _launch_result.rc == 0
 


### PR DESCRIPTION
The pre-launch capacity check in `molecule/shared/create.yml` has been retrying 30×30s (15 min) since the runner pool was rebuilt after the lab outage. Fine for one PR at a time, but the moment more than a couple of heavy PRs are open — beats_security, es_kibana, upgrade_multi_node, elasticsearch_diagnostics, elasticstack_default each want 8–20 GB — they lose the memory race against a swarm of 1–2 GB scenarios cycling through faster. A recent 5-PR merge sequence lit up five of those with matching "No capacity: X committed + Y needed > Z available" stdouts before we even looked at the actual test output.

Bumps `retries: 30 → 90` (45 min of patience) and lifts the standard `molecule.yml` default timeout from 45 to 60 minutes so the gate still fails loudly with the last-attempt stdout before GitHub Actions silently cancels the job. Per-caller overrides (elasticsearch=30, modules=20) stay put — those scenarios are small and dont starve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the workflow timeout to 60 minutes.
  * Extended container startup retries, allowing up to 45 minutes for capacity to become available.
  * Updated related timing documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->