### PR TITLE
feat(elasticsearch): raise vm.max_map_count to the 8.16+ recommended 1048576

### DIFF
--- a/molecule/elasticsearch_default/verify.yml
+++ b/molecule/elasticsearch_default/verify.yml
@@ -102,11 +102,11 @@
       run_once: true
       when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd', 'lxc', 'podman']
 
-    - name: Assert vm.max_map_count is 262144  # noqa: run-once[task]
+    - name: Assert vm.max_map_count is 1048576  # noqa: run-once[task]
       ansible.builtin.assert:
         that:
-          - _max_map_count.stdout | int == 262144
-        fail_msg: "vm.max_map_count is {{ _max_map_count.stdout }}, expected 262144"
+          - _max_map_count.stdout | int == 1048576
+        fail_msg: "vm.max_map_count is {{ _max_map_count.stdout }}, expected 1048576"
       run_once: true
       when: _max_map_count is not skipped
 

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -180,7 +180,7 @@
     state: present
     reload: true
   loop:
-    - { name: vm.max_map_count, value: "262144" }
+    - { name: vm.max_map_count, value: "1048576" }
     - { name: vm.swappiness, value: "1" }
     - { name: net.ipv4.tcp_retries2, value: "5" }
   loop_control:


### PR DESCRIPTION
Elasticsearch 8.16+ recommends vm.max_map_count=1048576 (the bootstrap check minimum stays 262144). The role pinned the old minimum, which also made it fight any site-level tuning that already sets the recommended value: last writer won and the effective value flip-flopped between runs and reboots. Molecule assertion updated.