### PR TITLE
fix(elasticsearch): use configurable retry budget on the post-restart health wait

### DIFF
--- a/roles/elasticsearch/tasks/elasticsearch-rolling-upgrade.yml
+++ b/roles/elasticsearch/tasks/elasticsearch-rolling-upgrade.yml
@@ -331,8 +331,8 @@
         ((elasticsearch_response.json | default({})).status | default('')) in _elasticsearch_upgrade_health_statuses
         and ((elasticsearch_response.json | default({})).number_of_nodes | default(0) | int)
             >= _elasticsearch_upgrade_expected_nodes | int
-      retries: 30
-      delay: 30
+      retries: "{{ elasticsearch_upgrade_health_retries | int }}"
+      delay: "{{ elasticsearch_upgrade_health_delay | int }}"
       vars:
         # Same gate as the pre-node-down health wait so both sides of the
         # rolling loop honour the same operator preference.


### PR DESCRIPTION
Companion fix to #198. The pre-node-down and post-restart health waits in the rolling upgrade are meant to be symmetric, but the post-restart wait had `retries: 30 / delay: 30` hardcoded while the pre-node-down wait uses `elasticsearch_upgrade_health_retries` (default 100) and `elasticsearch_upgrade_health_delay` (default 30).

On incus-ci debian12 the mixed-version 8→9 peer discovery routinely takes >15 min under load, which is exactly the 30×30 budget. That is the `attempts: 30, number_of_nodes: 1, status: yellow` timeout signature seen on the last few PRs (including #198 itself, where the node-count guard was correct but the retry cap kept it under water on debian12).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rolling upgrades by honoring the configured retry count and delay when waiting for cluster health after an upgrade.
  * Allows upgrade checks to better accommodate environments with varying recovery times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->